### PR TITLE
docs: Add --help flag and fix bootstrap line references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ The `.zshrc` file sources other configuration files in this order:
 - `precmd` calculates elapsed time after command completes
 - Timer only displayed if command takes >0 seconds
 
-**Bootstrap Process** (bootstrap.sh:76-100)
+**Bootstrap Process** (bootstrap.sh:172-201)
 - Uses `rsync` to sync `home/` directory contents to `~`
 - Installs tmux plugin manager (TPM) if not present
 - TPM must be manually activated in tmux with `prefix + I` after first install

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -211,6 +211,17 @@ for arg in "$@"; do
 	case "$arg" in
 		--force|-f) FORCE=true ;;
 		--pull|-p) PULL=true ;;
+		--help|-h)
+			echo "Usage: ./bootstrap.sh [OPTIONS]"
+			echo ""
+			echo "Install dotfiles from home/ to ~"
+			echo ""
+			echo "Options:"
+			echo "  -f, --force  Skip confirmation prompt"
+			echo "  -p, --pull   Pull latest changes before installing"
+			echo "  -h, --help   Show this help message"
+			exit 0
+			;;
 	esac
 done
 


### PR DESCRIPTION
## Summary
- Add -h/--help flag to bootstrap.sh showing usage and available options
- Update CLAUDE.md to reference correct line numbers for Bootstrap Process section

## Test plan
- [ ] Run `./bootstrap.sh --help` to verify help output displays correctly
- [ ] Verify line references in CLAUDE.md match actual bootstrap.sh content

🤖 Generated with [Claude Code](https://claude.com/claude-code)