### PR TITLE
feat: Auto-name tmux sessions after current directory

### DIFF
--- a/home/.tmux.conf
+++ b/home/.tmux.conf
@@ -19,6 +19,9 @@ set -g renumber-windows on
 setw -g automatic-rename on
 setw -g automatic-rename-format '#{pane_current_command}'
 
+# Auto-name new sessions after the current directory
+set-hook -g session-created 'run-shell "tmux rename-session $(basename #{pane_current_path})"'
+
 # Reduce escape time (important for vim)
 set -sg escape-time 10
 


### PR DESCRIPTION
## Summary
- Add `session-created` hook to automatically name new tmux sessions after the current directory
- Makes it easier to identify sessions when working on multiple projects

## Test plan
- [ ] Start tmux in a project directory (e.g., `~/projects/myapp`)
- [ ] Verify session is named after the directory (e.g., `myapp`)
- [ ] Verify duplicate names get a suffix appended

🤖 Generated with [Claude Code](https://claude.com/claude-code)