### PR TITLE
docs: Add pre-PR local review step to workflow

### DIFF
--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -13,6 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) for all sessions.
 
 ## PR Workflow
 
+- Before creating a PR, run `/pr-review-toolkit:review-pr` to locally check the quality of your changes.
 - After pushing a PR, watch CI with `gh pr checks <PR#> --watch --interval 5`, then fetch comments with `gh pr view <PR#> --comments`.
 - After CI code review completes, summarize all reviewer feedback and suggestions in a table with columns: #, Feedback, Opinion, Recommendation (address/skip).
 - When considering the code reviewer's feedback, provide honest analysis of each suggestion: assess whether it's worth addressing, explain the trade-offs, and recommend skipping items that don't provide proportional value.


### PR DESCRIPTION
## Summary
- Adds instruction to run `/pr-review-toolkit:review-pr` before creating a PR
- Positions the step at the beginning of the PR Workflow section, before post-push activities
- Helps catch quality issues locally before pushing changes

## Test plan
- [x] Verify the instruction is placed logically in the workflow sequence
- [x] Confirm markdown formatting is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)