### PR TITLE
docs: Add pre-PR documentation update reminder

### DIFF
--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -13,6 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) for all sessions.
 
 ## PR Workflow
 
+- Before creating a PR with significant changes, check that CLAUDE.md and README.md are updated to reflect the changes.
 - Before creating a PR, run `/pr-review-toolkit:review-pr` to locally check the quality of your changes.
 - After pushing a PR, watch CI with `gh pr checks <PR#> --watch --interval 5`, then fetch comments with `gh pr view <PR#> --comments`.
 - After CI code review completes, summarize all reviewer feedback and suggestions in a table with columns: #, Feedback, Opinion, Recommendation (address/skip).


### PR DESCRIPTION
## Summary
- Adds workflow step to check that CLAUDE.md and README.md are updated before creating PRs with significant changes
- Ensures documentation stays in sync with code changes

## Test plan
- [ ] Verify the new step appears in the PR Workflow section of CLAUDE.md
- [ ] Confirm the instruction is clear and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)