### PR TITLE
feat: Categorize /improve-workflow suggestions as local or global

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Minimal macOS dotfiles for zsh, git, vim, and tmux with automatic dark/light mod
 | `/audit-codebase` | Check for AI anti-patterns and Evergreen violations |
 | `/audit-tests` | Find redundant or stale tests |
 | `/audit-issues` | Categorize open issues as current or needing updates |
-| `/improve-workflow` | Suggest Claude Code config improvements |
+| `/improve-workflow` | Suggest workflow improvements, categorized as local or global |
 
 **Usage examples:**
 ```bash

--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -20,6 +20,7 @@ This file provides guidance to Claude Code (claude.ai/code) for all sessions.
 - Re-running flaky CI (once per failure)
 - Web searches for documentation/research
 - After completing implementation work: summarize changes and run `/pr-feedback --local`
+- After creating a PR: immediately run `/watch-ci <PR#>` to monitor CI
 
 ### Requires Discussion
 
@@ -93,6 +94,7 @@ After CI passes, run `/pr-feedback --remote` to fetch and process reviewer comme
 
 ## CI Handling
 
+- **Always run `/watch-ci <PR#>` immediately after creating a PR** - don't wait for user to ask
 - If CI fails due to flakiness, auto-rerun failed jobs once with `gh run rerun <run-id> --failed`
 - If CI fails twice, investigate the root cause
 
@@ -113,6 +115,6 @@ Available slash commands (in `~/.claude/commands/`):
 - `/audit-codebase` - Check for AI-generated anti-patterns and Evergreen violations
 - `/audit-tests` - Find redundant or stale tests
 - `/audit-issues` - Categorize open issues as current or needing updates
-- `/improve-workflow` - Suggest Claude Code features and config improvements
+- `/improve-workflow` - Suggest workflow improvements, categorized as local (this repo) or global (dotfiles)
 - `/watch-ci` - Monitor CI in background with notification when complete
 - `/commit-commands:commit-push-pr` - Commit, push, and create PR in one step (preferred for new PRs)

--- a/home/.claude/commands/improve-workflow.md
+++ b/home/.claude/commands/improve-workflow.md
@@ -13,10 +13,36 @@ References:
 
 $ARGUMENTS
 
+## Check Global Setup First
+
+Before making suggestions, read the global Claude configuration to filter out stale recommendations:
+
+```bash
+cat ~/.claude/CLAUDE.md
+```
+
+Skip any suggestion that:
+- Proposes a workflow already documented in the global CLAUDE.md
+- Recommends a command or hook that already exists
+- Suggests a permission that's already configured
+
 ## Output
 
 Be specific about what each suggestion enables and the setup required.
 
+Group suggestions into two categories:
+
+**Local Improvements** - Specific to the current repository:
+- Repository-specific CLAUDE.md additions
+- Project-specific hooks or automation
+- Documentation for this codebase
+
+**Global Improvements** - Apply to all Claude Code sessions:
+- New commands or workflow enhancements for `~/.claude/commands/`
+- Permission configuration changes for `~/.claude/settings.json`
+- Hook improvements for `~/.claude/hooks/`
+- Global CLAUDE.md workflow documentation updates
+
 ## Follow-up
 
-For any global workflow improvements (changes to ~/.claude/ config, new commands, hooks, etc.), create an issue on `evansenter/dotfiles` to track the improvement. Use appropriate labels if available.
+When suggesting to create an issue against `evansenter/dotfiles`, **only include Global Improvements**. Local improvements should be tracked in the current repository's issues.


### PR DESCRIPTION
## Summary

- Updates `/improve-workflow` to check global `~/.claude/CLAUDE.md` before making suggestions, filtering out stale recommendations that are already addressed
- Groups suggestions into **Local** (repo-specific) and **Global** (dotfiles) categories
- Only creates issues against `evansenter/dotfiles` for global improvements
- Adds reminder to always run `/watch-ci` after creating PRs (in both Autonomous Decisions and CI Handling sections)

## Test plan

- [ ] Run `/improve-workflow` in a non-dotfiles repo and verify suggestions are categorized
- [ ] Verify stale suggestions (already in global config) are filtered out
- [ ] Confirm `/watch-ci` reminder appears in updated CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)