### PR TITLE
docs: Document Claude Code commands, hooks, and plugins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,11 @@ The `.zshrc` file sources other configuration files in this order:
 - `CLAUDE.md` provides global workflow preferences for all Claude Code sessions
   - Symlinked to `~/.claude/CLAUDE.md` and applies to all projects
   - Supplements repository-level `CLAUDE.md` files at project roots
+- `commands/` contains custom slash commands (e.g., `/status-report`, `/pr-feedback`)
+- `hooks/notify.sh` provides cross-platform desktop notifications
+- `settings.json` configures:
+  - Allowed permissions for autonomous operation (git, gh CLI, GitHub MCP)
+  - Enabled plugins: feature-dev, pr-review-toolkit, code-review, commit-commands, LSP integrations
 
 **iTerm2 Configuration** (preferences/, vendor/iterm-catppuccin/)
 - Color schemes in `vendor/iterm-catppuccin/colors/`

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ brew install cormacrelf/tap/dark-notify
 ./bootstrap.sh  # Symlinks commands/, hooks/, settings.json, CLAUDE.md
 ```
 
-Also installs GitHub MCP server. Set `GITHUB_TOKEN` in `~/.extra`:
+Also installs GitHub MCP server and enables plugins (feature-dev, pr-review-toolkit, code-review, commit-commands, LSP integrations). Set `GITHUB_TOKEN` in `~/.extra`:
 ```bash
 export GITHUB_TOKEN="ghp_your_token_here"
 ```


### PR DESCRIPTION
## Summary
- Expand CLAUDE.md to document `commands/`, `hooks/notify.sh`, and `settings.json` configuration details
- Update README.md to mention enabled plugins in the Claude Code optional dependencies section
- Addresses gap where plugins configuration wasn't documented

## Test plan
- [ ] Verify documentation renders correctly on GitHub
- [ ] Confirm no information is duplicated unnecessarily

🤖 Generated with [Claude Code](https://claude.com/claude-code)