### PR TITLE
refactor: Streamline CLAUDE.md and fix README hooks description

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,124 +4,69 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Overview
 
-This is a minimal dotfiles repository for zsh, git, vim, and tmux. While primarily designed for macOS, it works on Linux with graceful degradation of macOS-specific features. Dotfiles live in `home/` and are symlinked to `~` on install. External themes are managed as git submodules in `vendor/`.
+Minimal dotfiles for zsh, git, vim, and tmux. Primarily macOS with Linux graceful degradation. Dotfiles in `home/` are symlinked to `~` on install. External themes are git submodules in `vendor/`.
 
-## Installation and Updates
+## Commands
 
-**Clone with submodules:**
 ```bash
-git clone --recursive <repo-url>
+./bootstrap.sh           # Install/sync dotfiles (prompts for confirmation)
+./bootstrap.sh -f        # Force install (skip confirmation)
+./bootstrap.sh --pull    # Pull latest then install
+./uninstall.sh           # Remove symlinks
+git submodule update --init --remote  # Update theme submodules
 ```
 
-**Install/sync dotfiles:**
-```bash
-./bootstrap.sh
-```
+## Testing Changes
 
-**Force update (skip confirmation):**
-```bash
-./bootstrap.sh -f
-```
+No formal test suite exists. To validate changes:
 
-**Pull latest and install:**
-```bash
-./bootstrap.sh --pull
-```
-
-**Update submodules:**
-```bash
-git submodule update --init --remote
-```
-
-**Uninstall:**
-```bash
-./uninstall.sh
-```
+1. **Shell configs** - Open a new terminal tab or `source ~/.zshrc`
+2. **Tmux** - Run `tmux source ~/.tmux.conf` or restart tmux
+3. **Git** - Test alias with `git <alias>`, e.g., `git st`
+4. **Bootstrap** - Run `./bootstrap.sh -f` to verify idempotent symlink creation
 
 ## Architecture
 
-### Configuration Loading Order
+### Zsh Loading Order
 
-The `.zshrc` file sources other configuration files in this order:
-
-1. `.exports` - Environment variables and PATH configuration
-2. `.zsh_prompt` - Prompt configuration with command timer hooks
+`.zshrc` sources files in this order:
+1. `.exports` - Environment variables, PATH
+2. `.zsh_prompt` - Prompt with command timer (uses `preexec`/`precmd` hooks)
 3. `.aliases` - Command aliases
-4. `~/.extra` - Personal customizations (not tracked in repo)
+4. `~/.extra` - Personal customizations (not tracked)
+
+### Bootstrap Process
+
+The `sync_dotfiles` function in `bootstrap.sh`:
+1. Symlinks all files in `home/` to `~` (idempotent - skips existing correct symlinks)
+2. Symlinks `.claude/hooks/` and `.claude/commands/` directories
+3. Installs Claude Code MCP servers (GitHub)
+4. Installs tmux plugin manager (TPM) - requires manual `prefix + I` to install plugins
+5. Symlinks btop themes from `vendor/btop-catppuccin/`
+6. Installs LaunchAgents (macOS only)
 
 ### Key Components
 
-**Prompt System** (home/.zsh_prompt:23-40)
-- Uses zsh hooks (`preexec` and `precmd`) to track command execution time
-- `preexec` captures start time before command runs
-- `precmd` calculates elapsed time after command completes
+**Prompt System** - `home/.zsh_prompt`
+- `preexec` captures start time, `precmd` calculates elapsed time
 - Timer only displayed if command takes >0 seconds
 
-**Bootstrap Process** (bootstrap.sh:139-156)
-- Symlinks all files in `home/` to corresponding locations in `~`
-- Skips files already correctly symlinked (idempotent)
-- Installs tmux plugin manager (TPM) if not present
-- TPM must be manually activated in tmux with `prefix + I` after first install
-- Symlinks btop themes from `vendor/btop-catppuccin/` to `~/.config/btop/themes/`
-- Auto-initializes git submodules if themes are missing
-- Installs LaunchAgents on macOS only (skipped on Linux)
-
-**Tmux Configuration** (home/.tmux.conf)
-- Uses Catppuccin theme (mocha flavor) for status bar styling
-- Custom key bindings: `|` for horizontal split, `-` for vertical split
-- Vim-style pane navigation with Ctrl-hjkl
-- Session resurrection with `prefix + S` (save) and `prefix + Y` (restore)
-- Auto-saves sessions every 15 minutes via tmux-continuum
-
-**Git Configuration** (home/.gitconfig)
-- Common aliases: `st`, `co`, `br`, `ci`, `lg`, `amend`, `unstage`, `discard`
-- Auto setup remote on push, prune on fetch
-- Default branch set to `main`
-- Uses GitHub CLI (`gh`) for credential management
-
-**Vim Configuration** (home/.vimrc)
-- 2-space indentation with spaces (expandtab)
-- Incremental, case-smart search with highlighting
-- No swap/backup files
-- Line numbers and always-visible status line
-- Uses Catppuccin mocha (dark) theme only; light mode switching not implemented
-
-**Dark Mode Theme Switching** (home/.bin/toggle-btop-theme)
-- Automatically switches btop theme based on macOS appearance
-- Uses catppuccin_mocha for dark mode, catppuccin_latte for light mode
+**Dark Mode Theme Switching** - `home/.bin/toggle-btop-theme`
+- Switches btop theme based on macOS appearance (mocha/latte)
 - Requires `dark-notify` (`brew install cormacrelf/tap/dark-notify`)
-- LaunchAgent runs dark-notify daemon to watch for appearance changes
-- Sends SIGUSR2 to running btop instances to reload theme immediately
+- LaunchAgent runs daemon, sends SIGUSR2 to btop instances
 
-**Claude Code Configuration** (home/.claude/)
-- `CLAUDE.md` provides global workflow preferences for all Claude Code sessions
-  - Symlinked to `~/.claude/CLAUDE.md` and applies to all projects
-  - Supplements repository-level `CLAUDE.md` files at project roots
-- `commands/` contains custom slash commands (e.g., `/status-report`, `/pr-feedback`)
-- `hooks/notify.sh` provides cross-platform desktop notifications
-- `settings.json` configures:
-  - Allowed permissions for autonomous operation (git, gh CLI, GitHub MCP)
-  - Enabled plugins: feature-dev, pr-review-toolkit, code-review, commit-commands, LSP integrations
+**Claude Code Configuration** - `home/.claude/`
+- `CLAUDE.md` - Global workflow preferences (symlinked to `~/.claude/CLAUDE.md`)
+- `commands/` - Custom slash commands (`/status-report`, `/pr-feedback`, etc.)
+- `hooks/notify.sh` - Cross-platform desktop notifications
+- `settings.json` - Allowed permissions, enabled plugins
 
-**iTerm2 Configuration** (preferences/, vendor/iterm-catppuccin/)
-- Color schemes in `vendor/iterm-catppuccin/colors/`
-- Profile backup in `preferences/iTerm Profile.json`
-- Manual setup required:
-  1. Import color schemes: Preferences → Profiles → Colors → Color Presets → Import
-  2. Enable auto-switching: Check "Use different colors for light mode and dark mode"
-  3. Set catppuccin-latte for light, catppuccin-mocha for dark
-- To restore profile: Preferences → Profiles → Other Actions → Import JSON Profiles
-
-## Personal Customizations
-
-Users can create `~/.extra` (not tracked) to add personal settings that override defaults. This file is sourced last in home/.zshrc:71-73.
+**iTerm2 Configuration** - `preferences/`, `vendor/iterm-catppuccin/`
+- Manual import required: Preferences → Profiles → Colors → Color Presets → Import
+- Enable "Use different colors for light mode and dark mode"
+- Profile backup: `preferences/iTerm Profile.json`
 
 ## After Merging Changes
 
-After merging a PR to this repo, run bootstrap to apply changes to the local system:
-
-```bash
-./bootstrap.sh -f
-```
-
-This ensures symlinks are updated and any new configurations take effect.
+Run `./bootstrap.sh -f` to apply changes to the local system.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ dotfiles/
 │   ├── .claude/
 │   │   ├── CLAUDE.md      # Global workflow preferences
 │   │   ├── commands/      # Custom slash commands
-│   │   ├── hooks/         # Stop hook, notification hook
+│   │   ├── hooks/         # Notification hook
 │   │   └── settings.json  # Plugins and hook config
 │   ├── .exports
 │   ├── .gitconfig


### PR DESCRIPTION
## Summary

- Condense CLAUDE.md by ~60% while retaining all essential information for Claude Code
- Remove stale line number references (e.g., `home/.zsh_prompt:23-40`) that become outdated
- Add new "Testing Changes" section documenting how to validate different config types
- Consolidate installation commands into single code block with inline comments
- Fix README.md hooks description (was "Stop hook, notification hook", now just "Notification hook")

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Confirm no essential information was lost
- [ ] Run `./bootstrap.sh -f` to verify instructions are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)