### PR TITLE
feat: Auto-create ~/.local/bin directory

### DIFF
--- a/home/.exports
+++ b/home/.exports
@@ -6,9 +6,8 @@
 #   GITHUB_TOKEN - Required for Claude Code GitHub MCP server
 
 # PATH configuration
-if [ -d "$HOME/.local/bin" ]; then
-    export PATH="$HOME/.local/bin:$PATH"
-fi
+[ -d "$HOME/.local/bin" ] || mkdir -p "$HOME/.local/bin"
+export PATH="$HOME/.local/bin:$PATH"
 
 # Default editor
 export EDITOR='vim'


### PR DESCRIPTION
Ensures the directory exists before adding to PATH, so it's always
available for user scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
