### PR TITLE
feat: Add tmux tiled layout binding (prefix +)

### DIFF
--- a/home/.tmux.conf
+++ b/home/.tmux.conf
@@ -43,6 +43,9 @@ bind r source-file ~/.tmux.conf \; display "Reloaded"
 # Equal-width columns layout
 bind \\ select-layout even-horizontal
 
+# Tiled layout (2x2 grid)
+bind + select-layout tiled
+
 # ==============================================================================
 # Plugins
 # ==============================================================================


### PR DESCRIPTION
## Summary

- Adds `prefix +` to trigger tiled layout (2x2 grid)
- Complements existing `prefix \` for even-horizontal

## Test plan

- [ ] `prefix +` arranges panes in grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)