### PR TITLE
feat: Add utility permissions (tmux, date, source, sed)

### DIFF
--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -49,6 +49,9 @@ Configured in `~/.claude/settings.json` for autonomous operation:
 **Build Tools:**
 - `make`, `cargo check/build/test/clippy/fmt/run/doc/add`
 
+**Utilities:**
+- `rm`, `tmux`, `date`, `source`, `sed`
+
 **GitHub MCP Server:**
 - PRs: `get_pull_request`, `list_pull_requests`, `get_pull_request_status`, `get_pull_request_files`, `get_pull_request_comments`, `get_pull_request_reviews`, `create_pull_request`, `merge_pull_request`, `update_pull_request_branch`, `create_pull_request_review`
 - Issues: `get_issue`, `list_issues`, `create_issue`, `update_issue`, `add_issue_comment`, `search_issues`

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -84,6 +84,10 @@
       "Skill(watch-ci)",
       "Skill(pr)",
       "Bash(rm:*)",
+      "Bash(tmux:*)",
+      "Bash(date:*)",
+      "Bash(source:*)",
+      "Bash(sed:*)",
       "Skill(rfc)"
     ],
     "defaultMode": "default"


### PR DESCRIPTION
## Summary

Adds commonly-used utility commands to the allowed permissions list to prevent future prompts.

## Changes

- Added `Bash(tmux:*)`, `Bash(date:*)`, `Bash(source:*)`, `Bash(sed:*)` to settings.json
- Documented utilities section in CLAUDE.md (including existing `rm`)

## Context

These commands were used during PR #61 session without blocking, but formalizing permissions:
1. Documents expected tool usage
2. Prevents potential future blocks
3. Aligns config with actual workflow

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)