### PR TITLE
feat: Propagate /audit-issues improvements to related commands

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,4 +38,4 @@ jobs:
 
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model opus --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/home/.claude/commands/im-lost.md
+++ b/home/.claude/commands/im-lost.md
@@ -31,7 +31,11 @@ gh pr view --json number,title,state,statusCheckRollup,reviewDecision,comments,b
 # (Read from conversation context)
 ```
 
-Parse the PR body for issue references (e.g., "Fixes #123", "Closes #45", or issue URLs). If found, fetch the linked issue for additional context.
+Parse the PR body for issue references (e.g., "Fixes #123", "Closes #45", or issue URLs). If found, fetch the linked issue including labels:
+
+```bash
+gh issue view <issue-number> --json title,labels
+```
 
 ### 2. Determine Workflow Position
 
@@ -58,6 +62,7 @@ Present in this format:
 **Status:** [uncommitted changes summary or "clean"]
 **PR:** [#N - title (CI status, N comments)] or "none"
 **Issue:** [#N - title] or "none"
+**Labels:** priority:high, bug, ... *(or "none" if no linked issue)*
 
 ### Workflow Position
 
@@ -89,3 +94,4 @@ Present in this format:
 - If stuck between steps, pick the earlier one
 - Reference active todos if any exist in the conversation
 - If working on an issue, always mention the issue number in Context and Suggested Next Action
+- Always show all labels from the linked issue (helps surface priority at a glance)

--- a/home/.claude/commands/pr.md
+++ b/home/.claude/commands/pr.md
@@ -164,7 +164,13 @@ Always include a final open-ended question for any additional comments.
 
 - **Implement**: Fix the item immediately
 - **Skip**: Note it was skipped, move on
-- **Defer**: Use `/rfc --create` to create an RFC issue, or create a simpler issue if appropriate
+- **Defer**: Use `/rfc --create` to create an RFC issue, or create a simpler issue with:
+  - A priority label based on severity/impact:
+    - `priority:high` - Blocks other work, critical bug
+    - `priority:medium` - Important but not urgent
+    - `priority:low` - Nice to have, backlog
+  - Any relevant type labels (bug, enhancement, etc.)
+  - **Note**: Run `gh label list` to check existing repo labels. Prefer existing labels, but suggest new ones if appropriate and notify the user before creating them.
 - **Elaborate**: Explain the topic, then re-ask
 
 #### 8. Re-check
@@ -276,7 +282,13 @@ Always include a final open-ended question for any additional comments.
 
 - **Implement**: Fix the item immediately
 - **Skip**: Note it was skipped, move on
-- **Defer**: Use `/rfc --create` to create an RFC issue, or create a simpler issue if appropriate
+- **Defer**: Use `/rfc --create` to create an RFC issue, or create a simpler issue with:
+  - A priority label based on severity/impact:
+    - `priority:high` - Blocks other work, critical bug
+    - `priority:medium` - Important but not urgent
+    - `priority:low` - Nice to have, backlog
+  - Any relevant type labels (bug, enhancement, etc.)
+  - **Note**: Run `gh label list` to check existing repo labels. Prefer existing labels, but suggest new ones if appropriate and notify the user before creating them.
 - **Elaborate**: Explain the topic, then re-ask
 
 #### 7. Push and Re-check

--- a/home/.claude/commands/status-report.md
+++ b/home/.claude/commands/status-report.md
@@ -96,17 +96,36 @@ Present the report in this format:
 | #N | One-sentence summary of what this PR does |
 
 **Open Issues** (N total)
-| Issue | Summary | Labels |
-|-------|---------|--------|
-| #N    | One-sentence summary of the issue | bug, enhancement |
+
+*Group issues by priority (high → medium → low → unlabeled):*
+
+| Issue | Summary | Priority | Labels |
+|-------|---------|----------|--------|
+| #N    | One-sentence summary | priority:high | bug |
+| #M    | Another issue summary | priority:medium | enhancement |
+| #K    | Low priority issue | priority:low | documentation |
+| #J    | Issue without priority | - | question |
+
+**Label Summary**
+
+| Label | Count |
+|-------|-------|
+| priority:high | N |
+| priority:medium | N |
+| priority:low | N |
+| (no priority) | N |
+| bug | N |
+| enhancement | N |
+
+*Note: Issues missing priority labels should be triaged with `/audit-issues`.*
 
 ### Recommendations
 
 Based on the current state, here are suggested next actions:
 
-1. **[Action]** - [Brief reasoning why this is recommended]
-2. **[Action]** - [Brief reasoning why this is recommended]
-3. **[Action]** - [Brief reasoning why this is recommended]
+1. **Work on #42 (priority:high)** - This high-priority issue has been open for 2 weeks and blocks feature X
+2. **Run `/audit-issues`** - 3 issues are missing priority labels, need triage
+3. **Clean up orphaned worktree** - `.worktrees/old-feature` has merged PR, run `/parallel-work cleanup`
 ```
 
 ### 4. Event Bus Activity (Optional)
@@ -137,15 +156,28 @@ If not registered with event bus, skip this section.
 
 ### 5. Recommendation Logic
 
-When making recommendations, consider:
+When making recommendations, consider and reference specific evidence:
+
+**Priority-based:**
+- **High priority issues**: Issues labeled `priority:high` should be addressed first
+- **Missing priority labels**: Suggest running `/audit-issues` to triage unlabeled issues
+
+**PR health:**
 - **Stale PRs**: Open PRs that may need attention (review, merge, or close)
+- **Failed CI in worktrees**: Worktrees with failing CI should be fixed
+- **Stacked PR updates**: If a base PR in a stack was updated, dependent PRs may need rebase
+
+**Workflow hygiene:**
+- **Dirty worktrees**: Worktrees with uncommitted changes need attention
+- **Orphaned worktrees**: Worktrees for merged/closed PRs can be cleaned up with `/parallel-work cleanup`
 - **Blocked issues**: Issues with "blocked" labels
+
+**Strategic:**
 - **Issue patterns**: If many similar issues exist, suggest consolidation
 - **Momentum**: If recent work focused on a feature area, suggest continuing there
 - **Quick wins**: Small issues or PRs that could be resolved easily
-- **Dirty worktrees**: Worktrees with uncommitted changes need attention
-- **Failed CI in worktrees**: Worktrees with failing CI should be fixed
-- **Orphaned worktrees**: Worktrees for merged/closed PRs can be cleaned up with `/parallel-work cleanup`
-- **Stacked PR updates**: If a base PR in a stack was updated, dependent PRs may need rebase
 
-Each recommendation should include a brief reason explaining why it's suggested based on the data gathered.
+Each recommendation MUST include:
+1. The specific evidence (e.g., "3 issues missing priority labels", "#42 is priority:high")
+2. The concrete action to take
+3. Brief reasoning why this matters


### PR DESCRIPTION
## Summary

- **`/status-report`**: Add priority grouping, label summary table, and evidence-based recommendations
- **`/im-lost`**: Show all labels from linked issue for quick priority visibility  
- **`/pr`**: Add priority label guidance when deferring creates simpler issues

This ensures consistent priority label usage across the workflow, building on the recent improvements to `/audit-issues`.

## Test plan

- [ ] Run `/status-report` and verify issues are grouped by priority with label summary
- [ ] Run `/im-lost` on a branch with a linked issue and verify labels are shown
- [ ] Test `/pr local` defer action and verify priority guidance is followed

🤖 Generated with [Claude Code](https://claude.com/claude-code)