### PR TITLE
feat: Add linked issue checking to claude-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write  # Needed to post comments
-      issues: read
+      issues: write         # Read linked issues, optionally comment if PR incomplete
       id-token: write
 
     steps:
@@ -51,4 +51,4 @@ jobs:
 
             Use the REPO and PR_NUMBER variables provided above.
           # Tools required by the centralized prompt (see contrib/prompts/claude-review.md)
-          claude_args: '--model opus --allowed-tools "Read,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh api:*)"'
+          claude_args: '--model opus --allowed-tools "Read,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh api:*)"'

--- a/home/.claude/contrib/prompts/claude-review.md
+++ b/home/.claude/contrib/prompts/claude-review.md
@@ -2,11 +2,13 @@
 
 <!--
 Required tools (must be in workflow's claude_args --allowed-tools):
-- Read                    - Read prompt file and CLAUDE.md
-- Bash(gh pr view:*)      - Get PR details and comments
-- Bash(gh pr diff:*)      - Get PR diff
-- Bash(gh pr comment:*)   - Post review comments
-- Bash(gh api:*)          - Fetch "Feedback Addressed" comments
+- Read                      - Read prompt file and CLAUDE.md
+- Bash(gh pr view:*)        - Get PR details and comments
+- Bash(gh pr diff:*)        - Get PR diff
+- Bash(gh pr comment:*)     - Post review comments
+- Bash(gh issue view:*)     - Read linked issues for context
+- Bash(gh issue comment:*)  - Comment on issue if PR incomplete (use sparingly)
+- Bash(gh api:*)            - Fetch "Feedback Addressed" comments
 -->
 
 You are reviewing a pull request. Be thorough and constructive.
@@ -16,7 +18,7 @@ You are reviewing a pull request. Be thorough and constructive.
 ### 1. Gather Context
 
 ```bash
-# Get PR details
+# Get PR details (check body for "Fixes #N" or "Closes #N")
 gh pr view $PR_NUMBER --json title,body,author,baseRefName,headRefName
 
 # Get the diff
@@ -29,7 +31,30 @@ gh pr view $PR_NUMBER --comments
 gh api repos/$REPO/issues/$PR_NUMBER/comments --jq '.[] | select(.body | contains("Feedback Addressed")) | .body'
 ```
 
-### 2. Check Previous Feedback Resolution
+### 2. Check Linked Issue (if any)
+
+If the PR body contains "Fixes #N", "Closes #N", or "Resolves #N", fetch the linked issue:
+
+```bash
+# Extract issue number from PR body and fetch it
+gh issue view $ISSUE_NUMBER
+```
+
+Use the linked issue to:
+- Understand the original requirements or bug report
+- Verify the PR addresses all acceptance criteria mentioned in the issue
+- Check for relevant discussion that provides context
+
+If the PR **does not fully address** the linked issue, note this in your review. In rare cases where the gap is significant, you may comment on the issue:
+
+```bash
+# Only use if PR clearly doesn't address critical requirements
+gh issue comment $ISSUE_NUMBER --body "PR #$PR_NUMBER addresses this partially but does not cover [specific gap]. See PR review for details."
+```
+
+**Use issue comments sparingly** - most feedback belongs on the PR, not the issue.
+
+### 3. Check Previous Feedback Resolution
 
 Before raising any issue, check if it was already addressed in a "Feedback Addressed" comment. These comments follow this format:
 
@@ -49,7 +74,7 @@ Before raising any issue, check if it was already addressed in a "Feedback Addre
 
 **Do NOT re-raise issues that appear in Implemented, Skipped, or Deferred sections.**
 
-### 3. Review Criteria
+### 4. Review Criteria
 
 Evaluate the code for:
 
@@ -71,7 +96,7 @@ Evaluate the code for:
    - Documentation gaps
    - Test coverage opportunities
 
-### 4. Review Standards
+### 5. Review Standards
 
 **Be strict about approval:**
 - If there are ANY Critical issues: REQUEST_CHANGES
@@ -81,7 +106,7 @@ Evaluate the code for:
 
 **Never LGTM with caveats.** If you have feedback, request changes.
 
-### 5. Output Format
+### 6. Output Format
 
 Post your review as a PR comment using `gh pr comment`:
 


### PR DESCRIPTION
## Summary
- Add `issues:write` permission for reading linked issues and commenting when needed
- Add `gh issue view` and `gh issue comment` to allowed tools
- Update prompt to check for linked issues (Fixes/Closes/Resolves #N)
- Verify PR addresses issue requirements and acceptance criteria
- Sparingly comment on issue if PR has significant gaps

## Use Cases
- **Issue read**: Understand original requirements, verify PR addresses all acceptance criteria
- **Issue comment**: Only for significant gaps where PR clearly doesn't address critical requirements (use sparingly)

## Test plan
- [ ] Create PR that references an issue, verify reviewer checks the issue
- [ ] Verify issue comments are only posted for significant gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)