### PR TITLE
feat: Auto-run /watch-ci after /pr remote push

### DIFF
--- a/home/.claude/commands/pr.md
+++ b/home/.claude/commands/pr.md
@@ -382,6 +382,7 @@ After implementing:
 2. Commit with message referencing feedback addressed
 3. Push changes
 4. Run `/pr local` to verify changes are clean
+5. Run `/watch-ci` to monitor CI for the new push
 
 ## Key Principle
 


### PR DESCRIPTION
## Summary
- Add step 5 to `/pr remote` section 8 (Push and Re-check) to automatically run `/watch-ci` after pushing feedback fixes

## Problem
During PR feedback cycles, after implementing fixes and pushing, users had to manually run `/watch-ci` to monitor CI. This added friction to each iteration cycle.

## Solution
Automatically run `/watch-ci` after push in the `/pr remote` workflow, matching the behavior of `/pr create` which already does this.

Fixes #67

## Test plan
- [ ] Create a PR, run `/pr remote`, address feedback, verify `/watch-ci` runs after push

🤖 Generated with [Claude Code](https://claude.com/claude-code)