### PR TITLE
feat: Add prompt source indicator to claude-review output

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -47,7 +47,7 @@ jobs:
             REPO: ${{ github.repository }}
             PR_NUMBER: ${{ github.event.pull_request.number }}
 
-            ${{ steps.prompt.outputs.use_file == 'true' && 'First, read the review instructions from /tmp/review-prompt.md using your Read tool. Then follow those instructions to review this PR.' || 'Review this PR for code quality, bugs, security issues, and adherence to project conventions (check CLAUDE.md). Check for previous "Feedback Addressed" comments to avoid re-raising resolved issues. Be strict: REQUEST_CHANGES for any issues found, only APPROVE if genuinely ready to merge. Post your review using gh pr comment.' }}
+            ${{ steps.prompt.outputs.use_file == 'true' && 'First, read the review instructions from /tmp/review-prompt.md using your Read tool. Then follow those instructions to review this PR.' || 'Review this PR for code quality, bugs, security issues, and adherence to project conventions (check CLAUDE.md). Check for previous "Feedback Addressed" comments to avoid re-raising resolved issues. Be strict: REQUEST_CHANGES for any issues found, only APPROVE if genuinely ready to merge. Post your review using gh pr comment. Start your comment with: > **Prompt:** Fallback (centralized prompt fetch failed)' }}
 
             Use the REPO and PR_NUMBER variables provided above.
           # Tools required by the centralized prompt (see contrib/prompts/claude-review.md)

--- a/home/.claude/contrib/prompts/claude-review.md
+++ b/home/.claude/contrib/prompts/claude-review.md
@@ -108,10 +108,14 @@ Evaluate the code for:
 
 ### 6. Output Format
 
-Post your review as a PR comment using `gh pr comment`:
+Post your review as a PR comment using `gh pr comment`.
+
+**Include prompt source** at the top so users know which review configuration was used:
 
 ```bash
 gh pr comment $PR_NUMBER --body "$(cat <<'EOF'
+> **Prompt:** [evansenter/dotfiles/.../claude-review.md](https://github.com/evansenter/dotfiles/blob/main/home/.claude/contrib/prompts/claude-review.md)
+
 ## Code Review
 
 ### Summary
@@ -139,7 +143,9 @@ EOF
 
 If no issues found:
 ```bash
-gh pr comment $PR_NUMBER --body "## Code Review
+gh pr comment $PR_NUMBER --body "> **Prompt:** [evansenter/dotfiles/.../claude-review.md](https://github.com/evansenter/dotfiles/blob/main/home/.claude/contrib/prompts/claude-review.md)
+
+## Code Review
 
 ### Summary
 [1-2 sentences on what this PR does]


### PR DESCRIPTION
## Summary
- Add prompt source indicator at the top of claude-review comments
- Centralized prompt: shows link to `evansenter/dotfiles/.../claude-review.md`
- Fallback prompt: indicates "Fallback (centralized prompt fetch failed)"

## Why
Helps users understand which review configuration was used, especially useful when debugging review behavior or after rolling out to new repos.

## Changes
- `home/.claude/contrib/prompts/claude-review.md`: Add prompt source to both output templates
- `.github/workflows/claude-code-review.yml`: Add fallback prompt source instruction

## Test plan
- [ ] This PR will test itself - claude-review should show the prompt source at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)