### PR TITLE
feat: Display event bus session name in statusline

### DIFF
--- a/home/.claude/hooks/session-start.sh
+++ b/home/.claude/hooks/session-start.sh
@@ -24,6 +24,22 @@ INPUT=$(cat)
 CWD=$(echo "$INPUT" | jq -r '.cwd // ""')
 [[ -z "$CWD" ]] && CWD="$PWD"
 CLIENT_ID=$(echo "$INPUT" | jq -r '.session_id // ""')
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // ""')
+
+# Compute session-specific key from transcript_path for multi-session support
+# Use simple hash that works on both macOS (md5) and Linux (md5sum)
+if [[ -n "$TRANSCRIPT_PATH" ]]; then
+    if command -v md5 &>/dev/null; then
+        SESSION_KEY=$(echo -n "$TRANSCRIPT_PATH" | md5 | cut -c1-12)
+    elif command -v md5sum &>/dev/null; then
+        SESSION_KEY=$(echo -n "$TRANSCRIPT_PATH" | md5sum | cut -c1-12)
+    else
+        # Fallback: use basename of transcript file
+        SESSION_KEY=$(basename "$TRANSCRIPT_PATH" .jsonl)
+    fi
+else
+    SESSION_KEY="default"
+fi
 
 # Derive session name (graceful fallback if git unavailable)
 REPO_NAME=$(basename "$CWD")
@@ -46,7 +62,7 @@ cat <<EOF
 <event-bus-registration>
 Register with event bus: mcp__event-bus__register_session(name: "$SESSION_NAME", cwd: "$CWD"$CLIENT_ID_ARG)
 After registration, persist the session_id for statusline display:
-  mkdir -p ~/.claude && echo "SESSION_ID_HERE" > ~/.claude/.event-bus-session-name
+  mkdir -p ~/.claude/.event-bus-sessions && echo "SESSION_ID_HERE" > ~/.claude/.event-bus-sessions/$SESSION_KEY
 </event-bus-registration>
 EOF
 

--- a/home/.claude/statusline-command.sh
+++ b/home/.claude/statusline-command.sh
@@ -34,12 +34,23 @@ MAGENTA=$'\e[35m'
 RESET=$'\e[0m'
 
 # Event bus session name (persisted by session-start hook)
+# Uses session-specific file keyed by transcript_path hash for multi-session support
 session_display=""
-session_file="$HOME/.claude/.event-bus-session-name"
-if [[ -r "$session_file" ]]; then
-    session_name=$(cat "$session_file" 2>/dev/null | tr -d '[:space:]')
-    if [[ -n "$session_name" ]]; then
-        session_display="${MAGENTA}[${session_name}]${RESET} "
+if [[ -n "$transcript_path" ]]; then
+    # Compute same hash as session-start.sh (works on macOS and Linux)
+    if command -v md5 &>/dev/null; then
+        session_key=$(echo -n "$transcript_path" | md5 | cut -c1-12)
+    elif command -v md5sum &>/dev/null; then
+        session_key=$(echo -n "$transcript_path" | md5sum | cut -c1-12)
+    else
+        session_key=$(basename "$transcript_path" .jsonl)
+    fi
+    session_file="$HOME/.claude/.event-bus-sessions/$session_key"
+    if [[ -r "$session_file" ]]; then
+        session_name=$(cat "$session_file" 2>/dev/null | tr -d '[:space:]')
+        if [[ -n "$session_name" ]]; then
+            session_display="${MAGENTA}[${session_name}]${RESET} "
+        fi
     fi
 fi
 


### PR DESCRIPTION
## Summary
- Display event bus session name (e.g., `[eager-rabbit]`) in Claude Code statusline
- Session name appears at the start of the statusline in magenta brackets
- Graceful fallback when session file doesn't exist

## Test plan
- [x] Verified session name displays correctly when file exists
- [x] Verified graceful fallback when file is absent
- [x] Verified hook outputs correct persistence instruction

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)