### PR TITLE
fix: Use full path to event-bus-cli in statusline

### DIFF
--- a/home/.claude/statusline-command.sh
+++ b/home/.claude/statusline-command.sh
@@ -37,14 +37,15 @@ RESET=$'\e[0m'
 # Event bus session name (queried live from event bus by client_id)
 # Uses Claude's session UUID to look up the nice-named event bus session
 session_display=""
-if [[ -n "$session_id" ]] && command -v event-bus-cli &>/dev/null; then
+EVENT_BUS_CLI="${HOME}/.local/bin/event-bus-cli"
+if [[ -n "$session_id" ]] && [[ -x "$EVENT_BUS_CLI" ]]; then
     # Query event bus for session matching this client_id
     # Use timeout to keep statusline responsive if event bus is slow
     # Output format is 3 lines per session:
     #   bright-tiger  dotfiles/main
     #     repo: dotfiles, machine: Evans-Personal-Pro.local
     #     age: 225s, client_id: a376d472-3afc-4917-aefc-a179a2ffb52d
-    session_name=$(timeout 1 event-bus-cli sessions 2>/dev/null | \
+    session_name=$(timeout 1 "$EVENT_BUS_CLI" sessions 2>/dev/null | \
         grep -B2 "client_id: ${session_id}" | \
         head -1 | \
         awk '{print $1}')


### PR DESCRIPTION
## Summary

Claude Code's statusline runs in a minimal environment without `~/.local/bin` in PATH. The `command -v event-bus-cli` check was failing, causing the session name to not appear in the statusline.

## Fix

Use explicit path `${HOME}/.local/bin/event-bus-cli` instead of relying on PATH.

## Test plan

- [x] Verified `event-bus-cli` lookup works with full path
- [ ] Session name appears in statusline after next CC refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)