### PR TITLE
feat: Show branch name in statusline when not on main/master

### DIFF
--- a/home/.claude/statusline-command.sh
+++ b/home/.claude/statusline-command.sh
@@ -207,13 +207,19 @@ else
     dir_display="${CYAN}${dir_name}${RESET}"
 fi
 
+# Branch display (show if not on default branch)
+branch_display=""
+if [[ -n "$branch" ]] && [[ "$branch" != "main" ]] && [[ "$branch" != "master" ]]; then
+    branch_display=":${MAGENTA}${branch}${RESET}"
+fi
+
 # Final hyperlink reset to ensure no unclosed hyperlinks leak
 LINK_RESET=$'\e]8;;\e\\'
 
 # Build the complete statusline
-output=$(printf "%s%s%s%s %s%s%s%s%s" \
+output=$(printf "%s%s%s%s%s %s%s%s%s%s" \
     "$session_display" \
-    "$dir_display" \
+    "$dir_display" "$branch_display" \
     "$pr_display" "$issue_display" \
     "$model_display" \
     "$git_status" "$context_display" "$user_context" \


### PR DESCRIPTION
## Summary

Displays the current branch name in the statusline when working on a feature branch. Hidden when on main or master to reduce noise.

**Format:** `[session] repo:branch #PR →#issue model ●dirty context%`

Example: `[warm-zebra] dotfiles:statusline-branch-name opus 42%`

## Test plan

- [x] Verified branch appears on feature branches
- [x] Verified branch hidden on main
- [ ] Verify on master branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)