### PR TITLE
feat: Add project stats to repo-stats.sh and cache statusline session lookup

### DIFF
--- a/home/.claude/statusline-command.sh
+++ b/home/.claude/statusline-command.sh
@@ -58,7 +58,7 @@ if [[ -n "$session_id" ]]; then
                 awk '{print $1}')
 
             # Cache the result (even if empty, to avoid repeated queries)
-            mkdir -p "$cache_dir" 2>/dev/null
+            mkdir -p "$cache_dir" && chmod 700 "$cache_dir" 2>/dev/null
             echo "$session_name" > "$cache_file" 2>/dev/null
         fi
 


### PR DESCRIPTION
## Summary
- Add **Project Stats** section to `repo-stats.sh` showing test counts, dependencies, open issues, and open PRs per repo
- Fix Rust test detection to search recursively (handles workspaces with multiple crates)
- Cache session name lookup in statusline to avoid repeated `list_sessions` calls

## Test plan
- [x] Run `~/.claude/contrib/repo-stats.sh --days 7` and verify Project Stats table appears
- [x] Verify Rust workspace test counts are accurate (gemicro: 503, rust-genai: 393)
- [x] Verify statusline still shows session name after cache is populated
- [ ] Confirm `list_sessions` calls reduced in event-bus logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)