### PR TITLE
feat: Add plan review step to /work and issue check to /improve-workflow

### DIFF
--- a/home/.claude/commands/improve-workflow.md
+++ b/home/.claude/commands/improve-workflow.md
@@ -198,6 +198,21 @@ Evaluate how analytics and event bus integrate with this central configuration:
 | **Prompt versioning** | Track CLAUDE.md and claude-remote.md changes over time | Understand prompt evolution |
 | **Prompt effectiveness** | Correlate prompt changes with session outcomes | Measure prompt improvements |
 
+### Check Existing Issues First
+
+Before suggesting any infrastructure improvement, check if an issue already exists:
+
+```
+mcp__github__list_issues(owner="evansenter", repo="claude-session-analytics", state="open")
+mcp__github__list_issues(owner="evansenter", repo="claude-event-bus", state="open")
+```
+
+For each potential suggestion:
+1. **If issue exists with same topic**: Don't suggest creating a new one. Instead, note:
+   - Whether the existing issue needs additional context from this session
+   - Whether to add a "+1" comment if the friction was significant
+2. **If no matching issue**: Include in Infrastructure Improvements section
+
 ### Output
 
 When meta-improvements are identified, include them in a separate section:
@@ -207,7 +222,11 @@ When meta-improvements are identified, include them in a separate section:
 - `evansenter/claude-event-bus` - Cross-session coordination
 - `evansenter/dotfiles` - Integration and workflow commands
 
-For each, specify:
+For each NEW suggestion (not already tracked), specify:
 1. What analysis or feature is missing
 2. What friction it would eliminate
 3. Concrete example from the current session
+
+For EXISTING issues that match session friction, note:
+- Issue number and title
+- Whether additional context should be added via comment

--- a/home/.claude/commands/work.md
+++ b/home/.claude/commands/work.md
@@ -89,7 +89,44 @@ For ad-hoc: Use the provided description.
 
 ultrathink to break down into 2-6 implementation tasks. Use imperative form.
 
-### 5. Create Todos
+### 5. Present Plan for Review
+
+Before creating todos or broadcasting, present the plan to the user:
+
+```
+## Proposed Work Plan
+
+**Source:** <issue reference OR ad-hoc description>
+**Identifier:** [work:<identifier>]
+
+### Implementation Tasks
+1. <task 1>
+2. <task 2>
+...
+
+### Checkpoints
+- Run /pr-review local
+- Create PR with /pr-create
+- Monitor CI with /watch-ci
+- Process feedback with /pr-review remote
+- Merge when approved
+- Reflect with /improve-workflow
+
+Proceed with this plan?
+```
+
+**Source formats:**
+- Issue: `#42 - Fix authentication timeout`
+- Ad-hoc: `"Add dark mode support"` (user's description)
+
+Use `AskUserQuestion` with options:
+- **Start work** - Create todos and begin
+- **Modify plan** - Adjust tasks before starting
+- **Cancel** - Abort without creating todos
+
+Only proceed to step 6 if user approves.
+
+### 6. Create Todos
 
 ```
 [work:${ID}] Implement: <task 1>
@@ -102,7 +139,7 @@ ultrathink to break down into 2-6 implementation tasks. Use imperative form.
 [work:${ID}] Checkpoint: Reflect with /improve-workflow
 ```
 
-### 6. Broadcast & Begin
+### 7. Broadcast & Begin
 
 ```
 mcp__event-bus__publish_event(event_type: "task_started", payload: "Started work on...", channel: "repo:<name>")


### PR DESCRIPTION
## Summary

- **`/work`**: Add step 5 to present proposed plan for user approval before creating todos and broadcasting. This prevents work from starting before the user reviews the implementation tasks.

- **`/improve-workflow`**: Add "Check Existing Issues First" section to verify infrastructure improvement suggestions against open issues in `claude-session-analytics` and `claude-event-bus` before proposing new ones. If an issue exists, note whether to add context or a "+1" instead of creating duplicates.

## Test plan

- [ ] Run `/work <issue-number>` and verify plan is presented before todos are created
- [ ] Run `/improve-workflow` and verify it checks existing issues before suggesting infrastructure improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)