### PR TITLE
feat: Show channel in event bus activity bullets

### DIFF
--- a/home/.claude/contrib/prompts/recent-events.md
+++ b/home/.claude/contrib/prompts/recent-events.md
@@ -2,6 +2,6 @@
 {{EVENTS}}
 </recent-events>
 
-**Display**: Show a "Recent event bus activity:" section with one-line bullet summaries including approximate time (e.g., "- CI passed on PR #125 (3 min ago)"). Only show events from the last ~10 minutes. Skip individual events already mentioned.
+**Display**: Show a "Recent event bus activity:" section with one-line bullet summaries including channel and approximate time (e.g., "- CI passed on PR #125 [repo:dotfiles] (3 min ago)"). Only show events from the last ~10 minutes. Skip individual events already mentioned.
 
 **Act on**: DMs to your session, help requests, CI failures, blockers. If a new issue was created in this repo, ask: "New issue #N created - want to pick it up with `/work N`?"


### PR DESCRIPTION
## Summary

- Update recent-events prompt to include channel in bullet summaries (e.g., `[repo:dotfiles]`)

## Before
```
- CI passed on PR #125 (3 min ago)
```

## After
```
- CI passed on PR #125 [repo:dotfiles] (3 min ago)
```

## Test plan

- [ ] Verify event bus activity displays with channel info on next prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)