### PR TITLE
feat: Show repo/session format in statusline

### DIFF
--- a/home/.claude/statusline-command.sh
+++ b/home/.claude/statusline-command.sh
@@ -37,7 +37,6 @@ RESET=$'\e[0m'
 
 # Event bus session name (cached per session_id to avoid repeated queries)
 # Uses Claude's session UUID to look up the nice-named event bus session
-session_display=""
 EVENT_BUS_CLI="${HOME}/.local/bin/event-bus-cli"
 if [[ -n "$session_id" ]]; then
     if [[ -x "$EVENT_BUS_CLI" ]]; then


### PR DESCRIPTION
## Summary

- Change statusline format from `[session] repo:branch` to `[repo/session]:branch`
- Repo shown in cyan with clickable GitHub link
- Session shown in magenta (or yellow warning if missing)
- Branch shown in blue (distinct from session color)

Matches event bus log format for consistency.

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)