### PR TITLE
feat: Add prefix = binding for even-vertical tmux layout

### DIFF
--- a/home/.tmux.conf
+++ b/home/.tmux.conf
@@ -43,6 +43,8 @@ bind r source-file ~/.tmux.conf \; display "Reloaded"
 
 # Equal-width columns layout
 bind \\ select-layout even-horizontal
+# Equal-height rows layout
+bind = select-layout even-vertical
 
 # Tiled layout (2x2 grid)
 bind + select-layout tiled


### PR DESCRIPTION
## Summary
- Adds `prefix =` → `even-vertical` layout (panes stacked in equal-height rows)

Complements existing layout bindings:
| Binding | Layout | Description |
|---------|--------|-------------|
| `prefix \` | even-horizontal | Side by side columns |
| `prefix =` | even-vertical | Stacked rows |
| `prefix +` | tiled | Grid |

## Test plan
- [x] Reload tmux config with `prefix r`
- [x] Create multiple panes, press `prefix =` to verify even-vertical layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)