### PR TITLE
fix: Use two-line statusline to avoid CC status injection

### DIFF
--- a/home/.claude/statusline-command.sh
+++ b/home/.claude/statusline-command.sh
@@ -190,7 +190,7 @@ if [[ "$size" =~ ^[0-9]+$ ]] && [[ "$current" =~ ^[0-9]+$ ]] && [ "$size" -gt 0 
     context_display=" ${GRAY}${pct}%${RESET}"
 fi
 
-# Last user message context (truncated to ~10 words)
+# Last user message context (truncated to 40 chars)
 user_context=""
 if [[ -n "$transcript_path" ]] && [[ -r "$transcript_path" ]]; then
     # Get last user message with string content (not tool result or system message)


### PR DESCRIPTION
## Summary

- Split statusline into two lines to prevent CC's built-in status from being concatenated
- Line 1: navigation context (repo/session, branch, PRs, issues, git status)
- Line 2: model info and user context (where CC can append its status)
- Truncate user context to 40 chars for cleaner display

## Problem

CC's "Context left until auto-compact: X%" message was being injected into the custom statusline, causing truncation and visual issues when the combined output exceeded terminal width.

## Test plan

- [x] `make check` passes
- [ ] Verify two-line statusline renders correctly in CC
- [ ] Verify CC's status messages no longer cause injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)