### PR TITLE
feat: Add timeout, cp, curl to allowed Bash commands

### DIFF
--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -52,6 +52,7 @@ Configured in `~/.claude/settings.json` for autonomous operation:
 **Utilities:**
 - `rm`, `tmux`, `date`, `source`, `sed`, `mkdir`
 - `ls`, `cat`, `head`, `tail`, `wc`, `chmod`
+- `timeout`, `cp`, `curl`
 - `uv`, `sqlite3`, `launchctl`, `claude`
 
 **Python:**

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -101,7 +101,10 @@
       "Bash(find:*)",
       "Bash(bash:*)",
       "Bash(which:*)",
-      "Bash(.venv/bin/python:*)"
+      "Bash(.venv/bin/python:*)",
+      "Bash(timeout:*)",
+      "Bash(cp:*)",
+      "Bash(curl:*)"
     ],
     "defaultMode": "default"
   },


### PR DESCRIPTION
## Summary
- Add `timeout`, `cp`, `curl` to allowed Bash commands in settings.json
- Document new permissions in CLAUDE.md utilities section

These are commonly-used safe utilities that currently require approval each time.

Fixes #141, fixes #146

## Test plan
- [x] Verify JSON syntax is valid
- [x] Verify documentation matches settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)