### PR TITLE
feat: Spawn summarize-work agent before merge confirmation

### DIFF
--- a/home/.claude/commands/work.md
+++ b/home/.claude/commands/work.md
@@ -125,7 +125,10 @@ Mark first task `in_progress`.
 
 **Process feedback**: Wait for CI, run `/pr-review remote`. If changes pushed, reset CI and feedback checkpoints, loop.
 
-**Confirm merge**: **Always** ask user via AskUserQuestion (Merge now / Wait). Never auto-merge. After merge:
+**Confirm merge**: Spawn summarize-work agent to show what's being merged:
+- `Task(subagent_type="summarize-work", prompt="Summarize work on this PR for merge review")`
+
+**Always** ask user via AskUserQuestion (Merge now / Wait). Never auto-merge. After merge:
 
 ```
 mcp__event-bus__publish_event(


### PR DESCRIPTION
## Summary

- Adds summarize-work agent spawn to the Confirm merge step in `/work` command
- User sees a summary of changes before being asked to merge
- Mirrors the pattern used for improve-workflow at the end of the workflow

## Test plan

- [ ] Run `/work` on a test PR, verify summarize-work runs before merge prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)