### PR TITLE
fix: Update event-bus hooks for --exclude flag rename

### DIFF
--- a/home/.claude/hooks/prompt-events.sh
+++ b/home/.claude/hooks/prompt-events.sh
@@ -36,7 +36,7 @@ EVENTS=$(event-bus-cli events \
     --resume \
     --session-id "$SESSION_ID" \
     --order asc \
-    --exclude-types session_registered,session_unregistered,ci_watching,task_started,ci_rerun,parallel_work_started \
+    --exclude session_registered,session_unregistered,ci_watching,task_started,ci_rerun,parallel_work_started \
     --timeout 200 \
     --limit 20 \
     2>/dev/null) || true

--- a/home/.claude/hooks/session-start.sh
+++ b/home/.claude/hooks/session-start.sh
@@ -66,7 +66,7 @@ fi
 EVENTS=$(event-bus-cli events \
     --session-id "$SESSION_ID" \
     --order desc \
-    --exclude-types session_registered,session_unregistered \
+    --exclude session_registered,session_unregistered \
     --timeout 200 \
     --limit 20 \
     2>/dev/null) || true
@@ -81,7 +81,7 @@ fi
 # If resuming after compaction, fetch and display WIP checkpoint
 if [[ "$SOURCE" == "compact" ]]; then
     # Fetch the most recent wip_checkpoint event for this session
-    # Note: CLI only has --exclude-types, so we filter with grep post-fetch
+    # Note: CLI has --include/--exclude but for specific types, use grep post-fetch
     WIP_EVENT=$(event-bus-cli events \
         --session-id "$SESSION_ID" \
         --channel "session:${SESSION_ID}" \

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -146,13 +146,13 @@ case "$1" in
         ;;
 
     events)
-        # Parse args - real CLI also accepts --order, --exclude-types, --timeout, --limit
+        # Parse args - real CLI also accepts --order, --include, --exclude, --timeout, --limit
         # Currently only --session-id affects output; others are accepted but ignored
         session_id=""
         while [[ $# -gt 1 ]]; do
             case "$2" in
                 --session-id) session_id="$3"; shift 2 ;;
-                --order|--exclude-types|--timeout|--limit) shift 2 ;;  # Accept but ignore
+                --order|--include|--exclude|--timeout|--limit) shift 2 ;;  # Accept but ignore
                 *) shift ;;
             esac
         done


### PR DESCRIPTION
## Summary

- Update `--exclude-types` to `--exclude` in event-bus hooks
- Required after event-bus PR #69 renamed the CLI flag

## Changes
- `session-start.sh`: Updated `--exclude-types` → `--exclude`
- `prompt-events.sh`: Updated `--exclude-types` → `--exclude`
- `test-hooks.sh`: Updated mock to accept new flag name

## Test plan

- [x] Tests pass locally
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)