### PR TITLE
fix: Strengthen merge approval language in CLAUDE.md

### DIFF
--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) for all sessions.
 
 ## Decision-Making
 
-- Use git and gh freely. Ask before merging or closing PRs.
+- Use git and gh freely. Never merge or close PRs without explicit user approval.
 - All repos have branch protection—create PRs, never push to main directly.
 - Prefer MCP tools for structured data; use gh CLI for `--watch` flags, runs, and arbitrary API calls.
 


### PR DESCRIPTION
## Summary

Changed "Ask before merging or closing PRs" to "Never merge or close PRs without explicit user approval"

The previous wording was too weak - allowed asking and immediately merging without waiting for confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)