### PR TITLE
feat: Increase tmux status bar widths for better visibility

### DIFF
--- a/home/.tmux.conf
+++ b/home/.tmux.conf
@@ -69,5 +69,10 @@ set -g @resurrect-restore 'Y'
 set -g @continuum-save-interval '15'
 
 
+# Status bar widths
+set -g status-left-length 30
+set -g status-right-length 60
+set -g status-right "\"#{=40:pane_title}\" %H:%M %d-%b-%y"
+
 # Initialize TPM (keep this at the very bottom)
 run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## Summary
- Increase left section from 10 to 30 chars (session name)
- Increase right section from 40 to 60 chars  
- Increase pane title limit from 21 to 40 chars

Prevents truncation of longer session names and pane titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)