### PR TITLE
fix: Conditional Notion MCP server installation

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -195,14 +195,16 @@ install_claude_mcp_servers() {
 		fi
 	fi
 
-	# Install Notion MCP server if not configured
-	if ! echo "$mcp_list" | grep -q "notion"; then
-		echo "Installing Notion MCP server..."
-		claude mcp add notion -s user -e 'NOTION_TOKEN=${NOTION_API_KEY}' -- npx -y @notionhq/notion-mcp-server
-
-		if [[ -z "${NOTION_API_KEY:-}" ]]; then
-			echo "  Warning: NOTION_API_KEY not set. Add to ~/.extra:"
-			echo "    export NOTION_API_KEY=\"ntn_your_token_here\""
+	# Install/remove Notion MCP server based on NOTION_API_KEY availability
+	if [[ -n "${NOTION_API_KEY:-}" ]]; then
+		if ! echo "$mcp_list" | grep -q "notion"; then
+			echo "Installing Notion MCP server..."
+			claude mcp add notion -s user -e 'NOTION_TOKEN=${NOTION_API_KEY}' -- npx -y @notionhq/notion-mcp-server
+		fi
+	else
+		if echo "$mcp_list" | grep -q "notion"; then
+			echo "Removing Notion MCP server (NOTION_API_KEY not set)..."
+			claude mcp remove notion -s user
 		fi
 	fi
 }


### PR DESCRIPTION
## Summary

- Only install Notion MCP server when `NOTION_API_KEY` is set
- Remove Notion MCP server if previously installed but key is no longer available
- Use `${NOTION_API_KEY:-}` to avoid unbound variable errors

## Test plan

- [x] Run `./bootstrap.sh -f` with `NOTION_API_KEY` set - server should be installed
- [x] Run `./bootstrap.sh -f` without `NOTION_API_KEY` - server should be removed if present

🤖 Generated with [Claude Code](https://claude.com/claude-code)