### PR TITLE
feat: Add common developer utilities to permission allowlist

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -107,7 +107,14 @@
       "Bash(.venv/bin/python:*)",
       "Bash(timeout:*)",
       "Bash(cp:*)",
-      "Bash(curl:*)"
+      "Bash(curl:*)",
+      "Bash(jq:*)",
+      "Bash(shellcheck:*)",
+      "Bash(diff:*)",
+      "Bash(ps:*)",
+      "Bash(tree:*)",
+      "Bash(touch:*)",
+      "Bash(rg:*)"
     ],
     "defaultMode": "default"
   },


### PR DESCRIPTION
## Summary

Add frequently-used developer utilities to the permission allowlist:
- `jq` - JSON processing
- `shellcheck` - Shell script linter
- `diff` - File comparison
- `ps` - Process listing
- `tree` - Directory structure display
- `touch` - File creation
- `rg` - ripgrep search

Closes #161

## Source

Identified by session-analytics improve-workflow agent analyzing 7 days of usage data.

## Test plan
- [x] JSON validated with `jq`

🤖 Generated with [Claude Code](https://claude.com/claude-code)