### PR TITLE
refactor: Flip bootstrap default to dotfiles-only, add --pull flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,10 @@ Minimal dotfiles for zsh, git, vim, and tmux. Supports macOS (Homebrew), Debian/
 ## Commands
 
 ```bash
-./bootstrap.sh           # Full sync: pull, install/update packages, sync dotfiles (prompts)
-./bootstrap.sh -f        # Full sync without confirmation
-./bootstrap.sh --no-sync # Just sync dotfiles (skip pull and packages)
+./bootstrap.sh           # Sync dotfiles (symlink home/ to ~, prompts for confirmation)
+./bootstrap.sh -f        # Sync dotfiles without confirmation
+./bootstrap.sh -p        # Also pull latest and install/update packages
+./bootstrap.sh -f -p     # Full sync without confirmation
 ./uninstall.sh           # Remove symlinks
 git submodule update --init --remote  # Update theme submodules
 ```
@@ -42,7 +43,7 @@ CI runs: Lint, Test, Hooks, Bootstrap, claude-review.
 
 `bootstrap.sh` runs two phases (see script for full details):
 
-**Phase 1 — Pull & packages** (skipped with `--no-sync`):
+**Phase 1 — Pull & packages** (only with `--pull`/`-p`):
 1. Pulls latest from git
 2. Installs packages: Homebrew (macOS), apt (Debian/Ubuntu), or binary downloads to `~/.local/bin` (SteamOS)
 3. Updates existing packages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Files in `home/` are symlinked to `~` by `bootstrap.sh`. This allows version con
 2. Run `./bootstrap.sh -f` to create the symlink
 3. The existing file will be replaced with a symlink to the dotfiles version
 
-**Symlink-breaking tools:** Some tools (CC, btop, zellij) do atomic writes that replace symlinks with regular files. Re-running `./bootstrap.sh --no-sync -f` restores them.
+**Symlink-breaking tools:** Some tools (CC, btop, zellij) do atomic writes that replace symlinks with regular files. Re-running `./bootstrap.sh -f` restores them.
 
 **Scaffolded directories:** Some directories are created by bootstrap but not symlinked. Example: `~/.openclaw/workspace/` — content is personal, generated via `openclaw configure`.
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Pull latest and sync:
 
 ```bash
 cd dotfiles
-./bootstrap.sh -f -s
+./bootstrap.sh -f -p
 git submodule update --init --remote
 ```
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1149,21 +1149,19 @@ sync_dotfiles() {
 
 # Parse arguments
 FORCE=false
-SYNC=true
+PULL=false
 for arg in "$@"; do
 	case "$arg" in
 		--force|-f) FORCE=true ;;
-		--sync|-s) SYNC=true ;;
-		--no-sync) SYNC=false ;;
+		--pull|-p) PULL=true ;;
 		--help|-h)
 			echo "Usage: ./bootstrap.sh [OPTIONS]"
 			echo ""
-			echo "Pull latest, install/update packages, and sync dotfiles"
+			echo "Sync dotfiles (symlink home/ to ~)"
 			echo ""
 			echo "Options:"
 			echo "  -f, --force    Skip confirmation prompt"
-			echo "  -s, --sync     Pull latest, install/update packages (default)"
-			echo "  --no-sync      Skip pull and package install, just sync dotfiles"
+			echo "  -p, --pull     Also pull latest and install/update packages"
 			echo "  -h, --help     Show this help message"
 			exit 0
 			;;
@@ -1171,7 +1169,7 @@ for arg in "$@"; do
 done
 
 # Pull, install, and update packages if requested
-if [[ "$SYNC" == true ]]; then
+if [[ "$PULL" == true ]]; then
 	pull_latest
 	install_packages
 	update_packages

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -159,7 +159,7 @@ test_openclaw_workspace_gitignore() {
 
 test_sync_dotfiles_no_package_install() {
     # sync_dotfiles must not call package installers directly — packages are
-    # handled by the SYNC guard so --no-sync skips them
+    # handled by the PULL guard so they only run with --pull
     local sync_body
     sync_body=$(sed -n '/^sync_dotfiles()/,/^}/p' "$BOOTSTRAP")
     ! echo "$sync_body" | grep -v '^\s*#' | grep -qE 'install_brew_packages|install_packages|install_apt_packages|install_steamos_packages'
@@ -244,16 +244,15 @@ read() { REPLY="y"; }
 
 # Mirror bootstrap.sh argument parsing and execution logic
 FORCE=false
-SYNC=true
+PULL=false
 for arg in "$@"; do
     case "$arg" in
         --force|-f) FORCE=true ;;
-        --sync|-s) SYNC=true ;;
-        --no-sync) SYNC=false ;;
+        --pull|-p) PULL=true ;;
     esac
 done
 
-if [[ "$SYNC" == true ]]; then
+if [[ "$PULL" == true ]]; then
     pull_latest
     install_packages
     update_packages
@@ -287,35 +286,20 @@ test_flag_help() {
     output=$("$BOOTSTRAP" --help 2>&1)
     echo "$output" | grep -q "Usage:" && \
     echo "$output" | grep -q "\-f, --force" && \
-    echo "$output" | grep -q "\-s, --sync"
+    echo "$output" | grep -q "\-p, --pull"
 }
 
 test_flag_force_only() {
-    # --force: full sync (default) without prompt
+    # --force: just sync dotfiles without prompt (no pull by default)
     local output
     output=$(run_bootstrap_with_mocks --force)
-    local line1 line2 line3 line4
-    line1=$(echo "$output" | sed -n '1p')
-    line2=$(echo "$output" | sed -n '2p')
-    line3=$(echo "$output" | sed -n '3p')
-    line4=$(echo "$output" | sed -n '4p')
-    [[ "$line1" == "pull_latest" ]] && \
-    [[ "$line2" == "install_packages" ]] && \
-    [[ "$line3" == "update_packages" ]] && \
-    [[ "$line4" == "sync_dotfiles" ]]
-}
-
-test_flag_no_sync() {
-    # --no-sync --force: just sync dotfiles, skip pull and packages
-    local output
-    output=$(run_bootstrap_with_mocks --no-sync --force)
     [[ "$output" == "sync_dotfiles" ]]
 }
 
-test_flag_sync_only() {
-    # --sync without --force prompts, our mock auto-confirms
+test_flag_pull_force() {
+    # --pull --force: pull, install packages, and sync dotfiles without prompt
     local output
-    output=$(run_bootstrap_with_mocks --sync)
+    output=$(run_bootstrap_with_mocks --pull --force)
     local line1 line2 line3 line4
     line1=$(echo "$output" | sed -n '1p')
     line2=$(echo "$output" | sed -n '2p')
@@ -327,9 +311,10 @@ test_flag_sync_only() {
     [[ "$line4" == "sync_dotfiles" ]]
 }
 
-test_flag_force_sync() {
+test_flag_pull_only() {
+    # --pull without --force prompts, our mock auto-confirms
     local output
-    output=$(run_bootstrap_with_mocks --force --sync)
+    output=$(run_bootstrap_with_mocks --pull)
     local line1 line2 line3 line4
     line1=$(echo "$output" | sed -n '1p')
     line2=$(echo "$output" | sed -n '2p')
@@ -342,9 +327,9 @@ test_flag_force_sync() {
 }
 
 test_flag_short_forms() {
-    # -s should work identically to --sync
+    # -p should work identically to --pull
     local output
-    output=$(run_bootstrap_with_mocks -f -s)
+    output=$(run_bootstrap_with_mocks -f -p)
     local line1 line2 line3 line4
     line1=$(echo "$output" | sed -n '1p')
     line2=$(echo "$output" | sed -n '2p')
@@ -357,18 +342,10 @@ test_flag_short_forms() {
 }
 
 test_flag_no_args_prompts() {
-    # No flags: full sync with prompt (mock auto-confirms)
+    # No flags: just sync dotfiles with prompt (mock auto-confirms), no pull
     local output
     output=$(run_bootstrap_with_mocks)
-    local line1 line2 line3 line4
-    line1=$(echo "$output" | sed -n '1p')
-    line2=$(echo "$output" | sed -n '2p')
-    line3=$(echo "$output" | sed -n '3p')
-    line4=$(echo "$output" | sed -n '4p')
-    [[ "$line1" == "pull_latest" ]] && \
-    [[ "$line2" == "install_packages" ]] && \
-    [[ "$line3" == "update_packages" ]] && \
-    [[ "$line4" == "sync_dotfiles" ]]
+    [[ "$output" == "sync_dotfiles" ]]
 }
 
 # ============================================================================
@@ -413,12 +390,11 @@ main() {
 
     echo "=== flag combinations ==="
     run_test "--help shows usage" "test_flag_help"
-    run_test "--force runs full sync without prompt" "test_flag_force_only"
-    run_test "--no-sync --force skips pull and packages" "test_flag_no_sync"
-    run_test "--sync runs pull+install+update+sync" "test_flag_sync_only"
-    run_test "--force --sync: full pipeline no prompt" "test_flag_force_sync"
-    run_test "short flags (-f -s) match long flags" "test_flag_short_forms"
-    run_test "no flags: full sync with prompt" "test_flag_no_args_prompts"
+    run_test "--force syncs dotfiles without prompt" "test_flag_force_only"
+    run_test "--pull --force: full pipeline no prompt" "test_flag_pull_force"
+    run_test "--pull runs pull+install+update+sync" "test_flag_pull_only"
+    run_test "short flags (-f -p) match long flags" "test_flag_short_forms"
+    run_test "no flags: sync dotfiles with prompt" "test_flag_no_args_prompts"
     echo ""
 
     # Summary


### PR DESCRIPTION
## Summary
- The old `--no-sync` flag was confusing — it sounded like it would skip syncing dotfiles, but actually skipped pull/packages
- Now the lightweight operation (symlink dotfiles) is the default, and `--pull`/`-p` opts into the heavier pull + package install
- Removed redundant `-s`/`--sync` flag that was a no-op (already the default)

## Test plan
- [ ] `./bootstrap.sh -h` shows updated help text
- [ ] `./bootstrap.sh -f` syncs dotfiles without pulling
- [ ] `./bootstrap.sh -f -p` pulls, installs packages, and syncs dotfiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)