### PR TITLE
fix: Prevent bootstrap from overwriting source files via symlinked parent dirs

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -138,6 +138,7 @@ symlink_dotfiles() {
 
 		# Skip if destination resolves back to the source (parent dir is symlinked into repo)
 		if [[ "$resolved_dest" == "$src_file" ]]; then
+			echo "Skipped: ~/$rel_path (parent dir symlinked into repo)"
 			continue
 		fi
 
@@ -159,7 +160,7 @@ symlink_dotfiles() {
 
 symlink_claude_dir() {
 	local dir_name="$1"
-	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 	local src_dir="$dotfiles_dir/home/.claude/$dir_name"
 	local dest_dir="$HOME/.claude/$dir_name"
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -115,7 +115,7 @@ install_github_binary() {
 }
 
 symlink_dotfiles() {
-	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 	# Find all files in home/ directory and create symlinks
 	# Exclude .claude/{hooks,commands,contrib,agents,skills}/ since we symlink those directories separately
@@ -124,8 +124,22 @@ symlink_dotfiles() {
 		local rel_path="${src_file#$dotfiles_dir/home/}"
 		local dest_file="$HOME/$rel_path"
 
-		# Create parent directory if needed
-		mkdir -p "$(dirname "$dest_file")"
+		# Create parent directory if needed, then resolve through symlinks to detect
+		# when a parent dir is symlinked back into the repo
+		local dest_parent
+		dest_parent="$(dirname "$dest_file")"
+		mkdir -p "$dest_parent"
+		local dest_dir
+		dest_dir="$(cd "$dest_parent" && pwd -P)" || {
+			echo "  Warning: cannot resolve $dest_parent, skipping ~/$rel_path"
+			continue
+		}
+		local resolved_dest="$dest_dir/$(basename "$dest_file")"
+
+		# Skip if destination resolves back to the source (parent dir is symlinked into repo)
+		if [[ "$resolved_dest" == "$src_file" ]]; then
+			continue
+		fi
 
 		# Skip if already correctly symlinked
 		if [[ -L "$dest_file" && "$(readlink "$dest_file")" == "$src_file" ]]; then


### PR DESCRIPTION
## Summary
- Adds a guard to `symlink_dotfiles()` that resolves destination paths through parent symlinks and skips when the resolved path matches the source file
- Prevents bootstrap from replacing its own source files with circular self-symlinks when a parent directory in `~` is symlinked back into the repo (e.g., `~/.config/zellij/scripts/` → `dotfiles/home/.config/zellij/scripts/`)
- Uses `pwd -P` consistently for both source and destination path resolution

## Test plan
- [x] `make check` passes (lint, test, hooks, bootstrap — 104 tests)
- [x] Verified `home/.config/zellij/scripts/sysload.sh` stays a regular file after bootstrap re-run
- [ ] Manual: create a symlinked parent dir scenario and confirm bootstrap skips correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)