### PR TITLE
Enforce ★ Insight → publish_event via Stop hook

### DIFF
--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -43,7 +43,7 @@ Non-obvious autonomy:
 
 After significant work: share what caused friction, where you were redirected (indicates missing guidance), and what's missing. Publish insights to event bus (`gotcha_discovered`, `pattern_found`, `improvement_suggested`).
 
-**★ Insight → Event Bus rule:** Every `★ Insight` block MUST be immediately followed by a `publish_event` call in the same response. Only skip if the insight is purely about a specific line in a specific file with zero cross-session value (rare). Default: publish.
+**★ Insight → Event Bus:** Insights worth emitting are worth publishing. When you emit an `★ Insight` block, publish it via `mcp__agent-event-bus__publish_event` in the same response. Exception: if the insight is purely about a specific line in a specific file with zero cross-session value, don't emit the block at all. A Stop hook (`enforce-insight-publish.sh`) enforces this — violations block the turn until you publish.
 
 ## PR Workflow
 

--- a/home/.claude/hooks/README.md
+++ b/home/.claude/hooks/README.md
@@ -35,8 +35,11 @@ Session Start
 │      │   - post-tool-failure.sh     │
 │      │   (detects recurring errors) │
 │      │                              │
-│      ├── Stop hook                  │
-│      │   - zj-status.sh waiting     │
+│      ├── Stop hooks (run in order): │
+│      │   1. zj-status.sh waiting    │
+│      │   2. enforce-insight-publish │
+│      │      (blocks if ★ Insight    │
+│      │       without publish_event) │
 │      │                              │
 │      ▼                              │
 │  (repeat)                           │
@@ -188,6 +191,30 @@ Session End / Agent Teams
 
 ---
 
+### enforce-insight-publish.sh
+**Trigger:** `Stop`
+
+**Purpose:** Enforce the "★ Insight → publish_event" rule from global CLAUDE.md. Blocks turn end if the assistant emitted one or more `★ Insight` blocks but made no `mcp__agent-event-bus__publish_event` tool calls in the same turn.
+
+**Actions:**
+1. Exit 0 if `stop_hook_active` is true (prevents infinite loop after a prior block)
+2. Exit 0 if `transcript_path` is missing or the file doesn't exist
+3. Parse the JSONL transcript to find the last "real" user message (string content, or array without `tool_result` blocks)
+4. Count `★ Insight ─` markers in assistant text blocks after that point
+5. Count `mcp__agent-event-bus__publish_event` tool_use blocks after that point
+6. If insights > 0 and publishes == 0, emit `{"decision": "block", "reason": "..."}` to force Claude to publish before the turn ends
+7. Otherwise exit silently
+
+Counting is lenient: one `publish_event` covers all insights in the turn (matches how insights are often batched into a single cross-session event).
+
+**Input JSON fields:** `session_id`, `transcript_path`, `stop_hook_active`, `cwd`
+
+**Output:** `{"decision": "block", "reason": "..."}` when the rule is violated. Silent otherwise.
+
+**Exit code:** Always 0. Blocking is signaled via the JSON `decision` field, not the exit code.
+
+---
+
 ### post-tool-failure.sh
 **Trigger:** `PostToolUseFailure`
 
@@ -247,7 +274,10 @@ In `settings.json`:
       { "type": "command", "command": "~/.claude/hooks/prompt-events.sh" },
       { "type": "command", "command": "~/.claude/hooks/zj-status.sh working" }
     ] }],
-    "Stop": [{ "hooks": [{ "type": "command", "command": "~/.claude/hooks/zj-status.sh waiting" }] }],
+    "Stop": [{ "hooks": [
+      { "type": "command", "command": "~/.claude/hooks/zj-status.sh waiting" },
+      { "type": "command", "command": "~/.claude/hooks/enforce-insight-publish.sh" }
+    ] }],
     "PreCompact": [{ "hooks": [{ "type": "command", "command": "~/.claude/hooks/pre-compact.sh" }] }],
     "TeammateIdle": [{ "hooks": [{ "type": "command", "command": "~/.claude/hooks/teammate-idle.sh" }] }],
     "TaskCreated": [{ "hooks": [{ "type": "command", "command": "~/.claude/hooks/task-created.sh" }] }],

--- a/home/.claude/hooks/enforce-insight-publish.sh
+++ b/home/.claude/hooks/enforce-insight-publish.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Stop hook: Enforces the "★ Insight → publish_event" rule from CLAUDE.md.
+#
+# Input (via stdin): JSON with transcript_path, stop_hook_active, session_id, cwd
+# Output: JSON {"decision":"block","reason":"..."} when violated; silent otherwise.
+#
+# Scans the current assistant turn (events after the last real user message)
+# for "★ Insight ─" markers in text blocks and mcp__agent-event-bus__publish_event
+# calls in tool_use blocks. If insights > 0 and publishes == 0, blocks the turn
+# and prompts Claude to publish before ending.
+#
+# Lenient counting: one publish_event covers all insights in the turn. Strict
+# counting could be added later if Claude games the lenient form.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Graceful degradation: no jq, nothing we can do.
+command -v jq >/dev/null 2>&1 || exit 0
+
+TRANSCRIPT_PATH=$(jq -r '.transcript_path // ""' <<<"$INPUT")
+STOP_HOOK_ACTIVE=$(jq -r '.stop_hook_active // false' <<<"$INPUT")
+
+# Prevent infinite loop: once we've blocked and Claude still didn't publish,
+# let the turn end to avoid trapping the session.
+[[ "$STOP_HOOK_ACTIVE" == "true" ]] && exit 0
+
+# No transcript to inspect → nothing to enforce.
+[[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]] && exit 0
+
+# Parse the transcript: find the last "real" user event (string content or
+# array without tool_result blocks), then count insight markers in text blocks
+# and publish_event calls in tool_use blocks that come after it.
+# Malformed transcript lines cause `jq -s` to fail hard; the `|| exit 0` below
+# is deliberate — we never want a broken transcript to trap the session by
+# repeatedly blocking Stop. Missing enforcement is preferable to missing exit.
+#
+# Marker regex: matches "★ Insight" followed by whitespace and 3+ divider
+# characters (U+2500 light, U+2501 heavy, U+2550 double) anchored at line
+# start. This excludes casual inline references like `the ★ Insight ─ marker`.
+# Code-fenced examples at column 0 will still match — accepted trade-off.
+ANALYSIS=$(jq -s '
+  def is_real_user:
+    .type == "user" and
+    ((.message.content | type) == "string"
+     or ((.message.content | type) == "array"
+         and all(.message.content[]; .type != "tool_result")));
+
+  . as $events
+  | [range(0; length) | select($events[.] | is_real_user)] as $user_idxs
+  | (if ($user_idxs | length) == 0 then 0 else ($user_idxs | last) + 1 end) as $start
+  | $events[$start:]
+  | {
+      insights: (
+        [ .[]
+          | select(.type == "assistant")
+          | .message.content[]?
+          | select(.type == "text")
+          | .text
+          | match("(?:^|\\n)★ Insight[ \\t]+[─━═]{3,}"; "g")
+        ] | length
+      ),
+      publishes: (
+        [ .[]
+          | select(.type == "assistant")
+          | .message.content[]?
+          | select(.type == "tool_use" and .name == "mcp__agent-event-bus__publish_event")
+        ] | length
+      )
+    }
+' "$TRANSCRIPT_PATH" 2>/dev/null) || exit 0
+
+INSIGHTS=$(jq -r '.insights // 0' <<<"$ANALYSIS")
+PUBLISHES=$(jq -r '.publishes // 0' <<<"$ANALYSIS")
+
+if [[ "$INSIGHTS" -gt 0 && "$PUBLISHES" -eq 0 ]]; then
+    MESSAGE="You emitted ${INSIGHTS} ★ Insight block(s) but made no publish_event calls this turn. Per global CLAUDE.md, publish insights to the event bus via mcp__agent-event-bus__publish_event before ending the turn. One publish_event can cover multiple related insights (lenient mode). If the insight is purely line-specific with no cross-session value, remove the ★ Insight block instead."
+    jq -n --arg msg "$MESSAGE" '{decision: "block", reason: $msg}'
+fi
+
+exit 0

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -32,6 +32,10 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/zj-status.sh waiting"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/enforce-insight-publish.sh"
           }
         ]
       }
@@ -126,7 +130,8 @@
     "explanatory-output-style@claude-plugins-official": true,
     "gopls-lsp@claude-plugins-official": true,
     "pyright-lsp@claude-plugins-official": true,
-    "typescript-lsp@claude-plugins-official": true
+    "typescript-lsp@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": true
   },
   "fastMode": true,
   "skipDangerousModePermissionPrompt": true

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -1347,10 +1347,18 @@ test_enforce_insight_publish_syntax() {
 }
 
 test_enforce_insight_publish_graceful_no_jq() {
-    local MINIMAL_PATH="/bin:/usr/bin"
+    # Build a PATH that has the hook's non-jq deps (cat, bash) but NOT jq.
+    # Using /bin:/usr/bin would find /usr/bin/jq on Debian/Ubuntu CI runners
+    # and cause the test to pass via the missing-transcript branch instead —
+    # masking a regression in the no-jq path.
+    local no_jq_dir="$TEST_TMP/no-jq"
+    mkdir -p "$no_jq_dir"
+    ln -sf "$(type -P cat)" "$no_jq_dir/cat"
+    ln -sf "$(type -P bash)" "$no_jq_dir/bash"
+
     local exit_code=0
     echo '{"transcript_path":"/tmp/fake.jsonl"}' | \
-        env -i PATH="$MINIMAL_PATH" HOME="$HOME" \
+        env -i PATH="$no_jq_dir" HOME="$HOME" \
         bash "$HOOKS_DIR/enforce-insight-publish.sh" >/dev/null 2>&1 || exit_code=$?
 
     # Must exit 0 when jq is missing (cannot enforce, must not block)

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -1339,6 +1339,198 @@ MOCK_CLI
 }
 
 # ============================================================================
+# enforce-insight-publish.sh tests
+# ============================================================================
+
+test_enforce_insight_publish_syntax() {
+    bash -n "$HOOKS_DIR/enforce-insight-publish.sh"
+}
+
+test_enforce_insight_publish_graceful_no_jq() {
+    local MINIMAL_PATH="/bin:/usr/bin"
+    local exit_code=0
+    echo '{"transcript_path":"/tmp/fake.jsonl"}' | \
+        env -i PATH="$MINIMAL_PATH" HOME="$HOME" \
+        bash "$HOOKS_DIR/enforce-insight-publish.sh" >/dev/null 2>&1 || exit_code=$?
+
+    # Must exit 0 when jq is missing (cannot enforce, must not block)
+    [[ $exit_code -eq 0 ]]
+}
+
+test_enforce_insight_publish_graceful_no_transcript() {
+    local exit_code=0
+    echo '{}' | bash "$HOOKS_DIR/enforce-insight-publish.sh" >/dev/null 2>&1 || exit_code=$?
+
+    [[ $exit_code -eq 0 ]]
+}
+
+test_enforce_insight_publish_graceful_missing_transcript_file() {
+    local exit_code=0
+    echo '{"transcript_path":"/nonexistent/path.jsonl"}' | \
+        bash "$HOOKS_DIR/enforce-insight-publish.sh" >/dev/null 2>&1 || exit_code=$?
+
+    [[ $exit_code -eq 0 ]]
+}
+
+test_enforce_insight_publish_respects_stop_hook_active() {
+    # When stop_hook_active=true, must not block (prevents infinite loop)
+    local transcript="$TEST_TMP/insight-no-publish.jsonl"
+    cat > "$transcript" <<'EOF'
+{"type":"user","message":{"role":"user","content":"hi"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"★ Insight ─────\nfoo"}]}}
+EOF
+
+    local output
+    local exit_code=0
+    output=$(echo "{\"transcript_path\":\"$transcript\",\"stop_hook_active\":true}" | \
+        bash "$HOOKS_DIR/enforce-insight-publish.sh" 2>&1) || exit_code=$?
+
+    # Must be silent when stop_hook_active is true
+    [[ $exit_code -eq 0 ]] && [[ -z "$output" ]]
+}
+
+# The mock jq in setup_test_env doesn't implement -s/slurp or match()/scan()
+# with complex queries. Tests that exercise the real jq pipeline discover the
+# real jq binary and prepend its directory, so they work both locally and on
+# CI runners regardless of where jq is installed (/opt/homebrew, /usr, etc.).
+_real_jq_path() {
+    local real_jq
+    real_jq=$(PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" command -v jq 2>/dev/null || true)
+    [[ -n "$real_jq" ]] && dirname "$real_jq" || echo "/usr/bin"
+}
+
+test_enforce_insight_publish_blocks_insight_without_publish() {
+    local transcript="$TEST_TMP/insight-no-publish.jsonl"
+    cat > "$transcript" <<'EOF'
+{"type":"user","message":{"role":"user","content":"tell me something"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Here you go.\n★ Insight ─────\nAn observation."}]}}
+EOF
+
+    local output
+    local exit_code=0
+    output=$(echo "{\"transcript_path\":\"$transcript\"}" | \
+        PATH="$(_real_jq_path):$PATH" \
+        bash "$HOOKS_DIR/enforce-insight-publish.sh" 2>&1) || exit_code=$?
+
+    # Must emit a block decision JSON
+    [[ $exit_code -eq 0 ]] && \
+    [[ "$output" == *"\"decision\": \"block\""* ]] && \
+    [[ "$output" == *"★ Insight"* ]]
+}
+
+test_enforce_insight_publish_allows_insight_with_publish() {
+    local transcript="$TEST_TMP/insight-with-publish.jsonl"
+    cat > "$transcript" <<'EOF'
+{"type":"user","message":{"role":"user","content":"tell me something"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"★ Insight ─────\nAn observation."}]}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"mcp__agent-event-bus__publish_event","input":{"event_type":"pattern_found","payload":"x"}}]}}
+EOF
+
+    local output
+    local exit_code=0
+    output=$(echo "{\"transcript_path\":\"$transcript\"}" | \
+        PATH="$(_real_jq_path):$PATH" \
+        bash "$HOOKS_DIR/enforce-insight-publish.sh" 2>&1) || exit_code=$?
+
+    # Must be silent when a publish_event accompanies the insight
+    [[ $exit_code -eq 0 ]] && [[ -z "$output" ]]
+}
+
+test_enforce_insight_publish_allows_no_insight() {
+    local transcript="$TEST_TMP/no-insight.jsonl"
+    cat > "$transcript" <<'EOF'
+{"type":"user","message":{"role":"user","content":"hi"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}
+EOF
+
+    local output
+    local exit_code=0
+    output=$(echo "{\"transcript_path\":\"$transcript\"}" | \
+        PATH="$(_real_jq_path):$PATH" \
+        bash "$HOOKS_DIR/enforce-insight-publish.sh" 2>&1) || exit_code=$?
+
+    [[ $exit_code -eq 0 ]] && [[ -z "$output" ]]
+}
+
+test_enforce_insight_publish_ignores_prior_turn_insights() {
+    # Insight in a prior turn (before the last user message) should not
+    # affect the current turn's enforcement.
+    local transcript="$TEST_TMP/prior-insight.jsonl"
+    cat > "$transcript" <<'EOF'
+{"type":"user","message":{"role":"user","content":"first"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"★ Insight ─────\nold insight (already dealt with)."}]}}
+{"type":"user","message":{"role":"user","content":"second"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"just a reply, no insight"}]}}
+EOF
+
+    local output
+    local exit_code=0
+    output=$(echo "{\"transcript_path\":\"$transcript\"}" | \
+        PATH="$(_real_jq_path):$PATH" \
+        bash "$HOOKS_DIR/enforce-insight-publish.sh" 2>&1) || exit_code=$?
+
+    [[ $exit_code -eq 0 ]] && [[ -z "$output" ]]
+}
+
+test_enforce_insight_publish_blocks_heavy_divider_variant() {
+    # ★ Insight ━ (U+2501 heavy) and ═ (U+2550 double) are valid variants
+    # some output styles use. Must also trigger enforcement.
+    local transcript="$TEST_TMP/heavy-divider.jsonl"
+    cat > "$transcript" <<'EOF'
+{"type":"user","message":{"role":"user","content":"tell me something"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"★ Insight ━━━━━━━\nHeavy divider.\n━━━━━━━"}]}}
+EOF
+
+    local output
+    local exit_code=0
+    output=$(echo "{\"transcript_path\":\"$transcript\"}" | \
+        PATH="$(_real_jq_path):$PATH" \
+        bash "$HOOKS_DIR/enforce-insight-publish.sh" 2>&1) || exit_code=$?
+
+    [[ $exit_code -eq 0 ]] && [[ "$output" == *"\"decision\": \"block\""* ]]
+}
+
+test_enforce_insight_publish_ignores_inline_mentions() {
+    # Casual inline mentions ("the ★ Insight ─ marker") should not trigger.
+    # Required: line-start + 3+ divider chars filters these out.
+    local transcript="$TEST_TMP/inline-mention.jsonl"
+    cat > "$transcript" <<'EOF'
+{"type":"user","message":{"role":"user","content":"explain the format"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"The ★ Insight ─ marker is how we write insights. Use `★ Insight ─` inline."}]}}
+EOF
+
+    local output
+    local exit_code=0
+    output=$(echo "{\"transcript_path\":\"$transcript\"}" | \
+        PATH="$(_real_jq_path):$PATH" \
+        bash "$HOOKS_DIR/enforce-insight-publish.sh" 2>&1) || exit_code=$?
+
+    [[ $exit_code -eq 0 ]] && [[ -z "$output" ]]
+}
+
+test_enforce_insight_publish_tool_results_stay_in_turn() {
+    # A tool_result is a user-typed event but must not be treated as a
+    # turn boundary. An insight after a tool result (same turn) still
+    # requires a publish_event.
+    local transcript="$TEST_TMP/tool-result-mid-turn.jsonl"
+    cat > "$transcript" <<'EOF'
+{"type":"user","message":{"role":"user","content":"do something"}}
+{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{}}]}}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"ok"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"★ Insight ─────\npost-tool observation."}]}}
+EOF
+
+    local output
+    local exit_code=0
+    output=$(echo "{\"transcript_path\":\"$transcript\"}" | \
+        PATH="$(_real_jq_path):$PATH" \
+        bash "$HOOKS_DIR/enforce-insight-publish.sh" 2>&1) || exit_code=$?
+
+    # Must still block: tool_result doesn't reset the turn.
+    [[ $exit_code -eq 0 ]] && [[ "$output" == *"\"decision\": \"block\""* ]]
+}
+
+# ============================================================================
 # Run all tests
 # ============================================================================
 
@@ -1445,6 +1637,21 @@ main() {
     run_test "graceful degradation (no jq)" "test_task_completed_graceful_no_jq"
     run_test "graceful degradation (no agent-event-bus-cli)" "test_task_completed_graceful_no_cli"
     run_test "integration: happy path" "test_task_completed_happy_path"
+    echo ""
+
+    echo "=== enforce-insight-publish.sh ==="
+    run_test "syntax check" "test_enforce_insight_publish_syntax"
+    run_test "graceful degradation (no jq)" "test_enforce_insight_publish_graceful_no_jq"
+    run_test "graceful degradation (no transcript_path)" "test_enforce_insight_publish_graceful_no_transcript"
+    run_test "graceful degradation (transcript file missing)" "test_enforce_insight_publish_graceful_missing_transcript_file"
+    run_test "respects stop_hook_active (loop guard)" "test_enforce_insight_publish_respects_stop_hook_active"
+    run_test "blocks insight without publish" "test_enforce_insight_publish_blocks_insight_without_publish"
+    run_test "allows insight with publish" "test_enforce_insight_publish_allows_insight_with_publish"
+    run_test "allows turns with no insight" "test_enforce_insight_publish_allows_no_insight"
+    run_test "ignores insights from prior turns" "test_enforce_insight_publish_ignores_prior_turn_insights"
+    run_test "blocks heavy/double divider variants" "test_enforce_insight_publish_blocks_heavy_divider_variant"
+    run_test "ignores inline marker mentions" "test_enforce_insight_publish_ignores_inline_mentions"
+    run_test "tool_result does not reset turn" "test_enforce_insight_publish_tool_results_stay_in_turn"
     echo ""
 
     echo "=== post-tool-failure.sh ==="


### PR DESCRIPTION
## Summary

- Adds `home/.claude/hooks/enforce-insight-publish.sh`, a Stop hook that parses the transcript JSONL for the current turn, counts `★ Insight` blocks vs `mcp__agent-event-bus__publish_event` tool calls, and returns `{"decision": "block", "reason": "..."}` if insights were emitted without a matching publish.
- Registers the hook in `home/.claude/settings.json` Stop array (appended after `zj-status.sh waiting`).
- Trims the `★ Insight → Event Bus` rule in `home/.claude/CLAUDE.md` to reference the hook as enforcement and preserve the exception logic.
- Updates `home/.claude/hooks/README.md` with a new section, updated lifecycle diagram, and config example.
- Adds 12 tests to `tests/test-hooks.sh` covering syntax, graceful degradation (no jq, no transcript, missing file, `stop_hook_active` loop guard), turn-boundary detection (tool_result is not a turn break), prior-turn isolation, divider variant matching (`─`, `━`, `═`), and inline-mention rejection.

## Why

The CLAUDE.md rule was soft — Claude dropped it frequently across sessions, losing cross-session insight capture. Prompt-space tuning tops out around 80–90% compliance; only a hook reaches ~100%.

## Design choices

- **Lenient counting**: one `publish_event` satisfies any number of insights in the turn. Matches how related insights are often batched into one event. Can be tightened later if the rule is gamed.
- **Regex**: `(?:^|\n)★ Insight[ \t]+[─━═]{3,}` — line-anchored, requires ≥3 divider chars, matches light/heavy/double box-drawing variants. Filters out inline mentions like `` `★ Insight ─` `` in prose. Code-fenced quoted examples at column 0 still match — accepted trade-off; the worst case is one throwaway publish.
- **Loop guard**: respects `stop_hook_active` to avoid trapping the session if Claude fails to publish after a block.
- **Graceful degradation**: missing `jq`, missing transcript, or malformed JSONL → exit 0 silently. Failure to enforce > failure to exit.

## Test plan

- [x] `make check` passes locally (29 bootstrap tests + 87 hook tests)
- [x] Shellcheck --severity=error clean
- [x] Manual smoke: insight-without-publish blocks, insight-with-publish allows, inline mentions silent, heavy/double variants block, short dividers (<3) don't trigger
- [ ] CI green

## Bundled change

`settings.json` also enables the `frontend-design` plugin — unrelated to the hook work but already uncommitted on main when this branch was cut. User explicitly asked to bundle rather than split.

Fixes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)