### PR TITLE
feat: Add Obsidian MCP server as persistent HTTP service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,8 +113,9 @@ Files in `home/` are symlinked to `~` by `bootstrap.sh`. This allows version con
 | agent-event-bus | 8080 | `/agent-event-bus` | `com.evansenter.agent-event-bus` |
 | agent-session-analytics | 8081 | `/agent-session-analytics` | `com.evansenter.agent-session-analytics` |
 | agent-memory-store | 8083 | `/agent-memory-store` | `com.evansenter.agent-memory-store` |
+| obsidian-mcp | 3010 | `/obsidian-mcp` | `com.evansenter.obsidian-mcp` |
 
-LaunchAgent plists live in `~/Library/LaunchAgents/`. Each service repo has `make install-server` to set up. Reload with `launchctl unload` + `launchctl load`.
+LaunchAgent plists live in `~/Library/LaunchAgents/`. Each service repo has `make install-server` to set up. Reload with `launchctl unload` + `launchctl load`. The obsidian-mcp LaunchAgent is managed by this repo (plist in `LaunchAgents/`, wrapper in `home/.bin/obsidian-mcp-start`). Requires Obsidian with the Local REST API plugin running.
 
 **Important:** Never place projects in `~/Documents/` — macOS TCC blocks LaunchAgents from accessing it, causing silent `PermissionError` failures.
 

--- a/LaunchAgents/com.evansenter.obsidian-mcp.plist
+++ b/LaunchAgents/com.evansenter.obsidian-mcp.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.evansenter.obsidian-mcp</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__HOME__/.bin/obsidian-mcp-start</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/.local/log/obsidian-mcp.stdout</string>
+
+    <key>StandardErrorPath</key>
+    <string>__HOME__/.local/log/obsidian-mcp.err</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1088,9 +1088,9 @@ install_claude_mcp_servers() {
 
 		echo "Installing Obsidian MCP server..."
 		if [[ "${HOSTNAME%%.*}" == "mac-mini" ]]; then
-			claude mcp add obsidian -s user --url http://localhost:3010/mcp
+			claude mcp add --transport http -s user obsidian http://localhost:3010/mcp
 		else
-			claude mcp add obsidian -s user --url "https://${GATEWAY_HOST}/obsidian-mcp/mcp"
+			claude mcp add --transport http -s user obsidian "https://${GATEWAY_HOST}/obsidian-mcp/mcp"
 		fi
 
 		if [[ -z "${OBSIDIAN_API_KEY:-}" ]]; then

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -278,7 +278,7 @@ install_npm_package() {
 	local npm_prefix
 	npm_prefix="$(npm config get prefix 2>/dev/null)"
 	if [[ -n "$npm_prefix" && -d "$npm_prefix/lib/node_modules" ]]; then
-		find "$npm_prefix/lib/node_modules" -maxdepth 1 -name ".${package}-*" -type d -mmin +60 -exec rm -rf {} + 2>/dev/null
+		find "$npm_prefix/lib/node_modules" -maxdepth 1 -name ".${package}-*" -type d -mmin +60 -exec rm -rf {} + 2>/dev/null || true
 	fi
 	# Use explicit registry to avoid custom registry misconfigurations
 	if ! npm install -g --registry https://registry.npmjs.org/ "$install_spec" 2>&1; then
@@ -446,8 +446,8 @@ install_launch_agents() {
 		install_launch_agent "com.user.cargo-sweep.plist"
 	fi
 
-	# Install Obsidian MCP LaunchAgent (only if obsidian-mcp-server is installed)
-	if command -v obsidian-mcp-server >/dev/null 2>&1; then
+	# Install Obsidian MCP LaunchAgent (only on gateway host where the server runs)
+	if [[ "${HOSTNAME%%.*}" == "mac-mini" ]] && command -v obsidian-mcp-server >/dev/null 2>&1; then
 		install_launch_agent "com.evansenter.obsidian-mcp.plist"
 	fi
 }
@@ -1084,18 +1084,16 @@ install_claude_mcp_servers() {
 
 	# Install Obsidian MCP server if not configured
 	if ! echo "$mcp_list" | grep -q "obsidian"; then
-		install_npm_package "obsidian-mcp-server" "Obsidian MCP Server"
-
-		echo "Installing Obsidian MCP server..."
 		if [[ "${HOSTNAME%%.*}" == "mac-mini" ]]; then
+			install_npm_package "obsidian-mcp-server" "Obsidian MCP Server"
 			claude mcp add --transport http -s user obsidian http://localhost:3010/mcp
+
+			if [[ -z "${OBSIDIAN_API_KEY:-}" ]]; then
+				echo "  Warning: OBSIDIAN_API_KEY not set. Add to ~/.extra:"
+				echo "    export OBSIDIAN_API_KEY=\"your-api-key-here\""
+			fi
 		else
 			claude mcp add --transport http -s user obsidian "https://${GATEWAY_HOST}/obsidian-mcp/mcp"
-		fi
-
-		if [[ -z "${OBSIDIAN_API_KEY:-}" ]]; then
-			echo "  Warning: OBSIDIAN_API_KEY not set. Add to ~/.extra:"
-			echo "    export OBSIDIAN_API_KEY=\"your-api-key-here\""
 		fi
 	fi
 }

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,6 +9,12 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE}")";
 
 # ==============================================================================
+# Constants
+# ==============================================================================
+
+GATEWAY_HOST="mac-mini.tailac7b3c.ts.net"
+
+# ==============================================================================
 # Functions
 # ==============================================================================
 
@@ -268,6 +274,12 @@ install_npm_package() {
 	fi
 
 	echo "Installing $display_name..."
+	# Clean up stale npm temp directories that cause install failures
+	local npm_prefix
+	npm_prefix="$(npm config get prefix 2>/dev/null)"
+	if [[ -n "$npm_prefix" && -d "$npm_prefix/lib/node_modules" ]]; then
+		find "$npm_prefix/lib/node_modules" -maxdepth 1 -name ".${package}-*" -type d -mmin +60 -exec rm -rf {} + 2>/dev/null
+	fi
 	# Use explicit registry to avoid custom registry misconfigurations
 	if ! npm install -g --registry https://registry.npmjs.org/ "$install_spec" 2>&1; then
 		echo ""
@@ -290,7 +302,6 @@ configure_claude_local_settings() {
 	# (correct for mac-mini gateway host). Override with Tailscale URLs in the
 	# untracked settings.local.json so remote machines reach services over the network.
 	local settings_local="$HOME/.claude/settings.local.json"
-	local gateway_host="mac-mini.tailac7b3c.ts.net"
 
 	# Skip if this is the gateway host (services run locally)
 	if [[ "${HOSTNAME%%.*}" == "mac-mini" ]]; then
@@ -309,8 +320,8 @@ configure_claude_local_settings() {
 		if command -v jq &>/dev/null; then
 			local tmp
 			tmp=$(mktemp)
-			if jq --arg bus "https://${gateway_host}/agent-event-bus/mcp" \
-			   --arg analytics "https://${gateway_host}/agent-session-analytics/mcp" \
+			if jq --arg bus "https://${GATEWAY_HOST}/agent-event-bus/mcp" \
+			   --arg analytics "https://${GATEWAY_HOST}/agent-session-analytics/mcp" \
 			   '.env = (.env // {}) + {"AGENT_EVENT_BUS_URL": $bus, "AGENT_SESSION_ANALYTICS_URL": $analytics}' \
 			   "$settings_local" > "$tmp" 2>/dev/null; then
 				mv "$tmp" "$settings_local"
@@ -329,8 +340,8 @@ configure_claude_local_settings() {
 		cat > "$settings_local" << EOF
 {
   "env": {
-    "AGENT_EVENT_BUS_URL": "https://${gateway_host}/agent-event-bus/mcp",
-    "AGENT_SESSION_ANALYTICS_URL": "https://${gateway_host}/agent-session-analytics/mcp"
+    "AGENT_EVENT_BUS_URL": "https://${GATEWAY_HOST}/agent-event-bus/mcp",
+    "AGENT_SESSION_ANALYTICS_URL": "https://${GATEWAY_HOST}/agent-session-analytics/mcp"
   }
 }
 EOF
@@ -433,6 +444,11 @@ install_launch_agents() {
 	# Install cargo-sweep LaunchAgent (only if cargo is installed)
 	if command -v cargo >/dev/null 2>&1; then
 		install_launch_agent "com.user.cargo-sweep.plist"
+	fi
+
+	# Install Obsidian MCP LaunchAgent (only if obsidian-mcp-server is installed)
+	if command -v obsidian-mcp-server >/dev/null 2>&1; then
+		install_launch_agent "com.evansenter.obsidian-mcp.plist"
 	fi
 }
 
@@ -1063,6 +1079,23 @@ install_claude_mcp_servers() {
 		if [[ -z "${GITHUB_TOKEN:-}" ]]; then
 			echo "  Warning: GITHUB_TOKEN not set. Add to ~/.extra:"
 			echo "    export GITHUB_TOKEN=\"ghp_your_token_here\""
+		fi
+	fi
+
+	# Install Obsidian MCP server if not configured
+	if ! echo "$mcp_list" | grep -q "obsidian"; then
+		install_npm_package "obsidian-mcp-server" "Obsidian MCP Server"
+
+		echo "Installing Obsidian MCP server..."
+		if [[ "${HOSTNAME%%.*}" == "mac-mini" ]]; then
+			claude mcp add obsidian -s user --url http://localhost:3010/mcp
+		else
+			claude mcp add obsidian -s user --url "https://${GATEWAY_HOST}/obsidian-mcp/mcp"
+		fi
+
+		if [[ -z "${OBSIDIAN_API_KEY:-}" ]]; then
+			echo "  Warning: OBSIDIAN_API_KEY not set. Add to ~/.extra:"
+			echo "    export OBSIDIAN_API_KEY=\"your-api-key-here\""
 		fi
 	fi
 }

--- a/home/.bin/obsidian-mcp-start
+++ b/home/.bin/obsidian-mcp-start
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Wrapper script for obsidian-mcp-server LaunchAgent.
+# Sources ~/.extra to pick up OBSIDIAN_API_KEY, then execs the server in HTTP mode.
+
+set -euo pipefail
+
+# Source secrets (OBSIDIAN_API_KEY lives here)
+if [[ -f "$HOME/.extra" ]]; then
+	# shellcheck source=/dev/null
+	source "$HOME/.extra"
+fi
+
+if [[ -z "${OBSIDIAN_API_KEY:-}" ]]; then
+	echo "Error: OBSIDIAN_API_KEY not set. Add to ~/.extra:" >&2
+	echo "  export OBSIDIAN_API_KEY=\"your-api-key-here\"" >&2
+	exit 1
+fi
+
+export MCP_TRANSPORT_TYPE="http"
+export MCP_HTTP_PORT="3010"
+export MCP_HTTP_HOST="127.0.0.1"
+export OBSIDIAN_BASE_URL="${OBSIDIAN_BASE_URL:-http://127.0.0.1:27123}"
+
+exec obsidian-mcp-server

--- a/home/.bin/obsidian-mcp-start
+++ b/home/.bin/obsidian-mcp-start
@@ -19,6 +19,7 @@ fi
 export MCP_TRANSPORT_TYPE="http"
 export MCP_HTTP_PORT="3010"
 export MCP_HTTP_HOST="127.0.0.1"
-export OBSIDIAN_BASE_URL="${OBSIDIAN_BASE_URL:-http://127.0.0.1:27123}"
+export OBSIDIAN_BASE_URL="${OBSIDIAN_BASE_URL:-https://127.0.0.1:27124}"
+export OBSIDIAN_VERIFY_SSL="${OBSIDIAN_VERIFY_SSL:-false}"
 
 exec obsidian-mcp-server


### PR DESCRIPTION
## Summary

- Add `obsidian-mcp-server` as a persistent HTTP MCP service on mac-mini, following the existing event-bus LaunchAgent pattern
- Create wrapper script (`home/.bin/obsidian-mcp-start`) that sources `~/.extra` for `OBSIDIAN_API_KEY` and execs the server in HTTP mode on port 3010
- Add LaunchAgent plist with conditional `KeepAlive` (`SuccessfulExit: false` + `ThrottleInterval: 30`) to avoid restart loops when Obsidian isn't running
- Bootstrap registers MCP at `localhost:3010` on mac-mini or Tailscale URL on remote machines
- Extract `GATEWAY_HOST` constant to eliminate duplication between `configure_claude_local_settings` and `install_claude_mcp_servers`

Fixes #302

## Test plan

- [ ] Verify `make check` passes (lint, test, hooks, bootstrap)
- [ ] Run `./bootstrap.sh -f` on mac-mini to confirm LaunchAgent installs and MCP registers
- [ ] Confirm `obsidian-mcp-server` starts and connects to Obsidian's Local REST API
- [ ] Verify `claude mcp list` shows obsidian as connected
- [ ] Test from remote machine: MCP registers with Tailscale URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)