### PR TITLE
docs: hook gotchas + improvement-shape guidance

### DIFF
--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -17,7 +17,7 @@ Don't wait to be asked. When you notice these patterns, surface them unprompted:
 - Documentation drifted from reality
 - Workflow friction you experienced during the session
 
-Propose concrete solutions, not just observations.
+Propose concrete solutions, not just observations. For low-trigger-rate fixes, prefer memory/event-bus/docs over skill-prompt edits — skill edits tax every invocation across all sessions.
 
 ### Autonomous Decisions
 

--- a/home/.claude/hooks/README.md
+++ b/home/.claude/hooks/README.md
@@ -262,6 +262,22 @@ Additional fields vary by hook type.
 ### Testing
 Run `make test-hooks` to test all hooks. Add tests for new hooks in `tests/test-hooks.sh`.
 
+### Gotchas
+
+**jq multiline regex: prefer explicit alternation over `^`+`m` flag.** In jq 1.8.1, `scan("^pattern"; "m")` can silently fail to match at line starts, especially when `^` is near a character class. Use `match("(?:^|\\n)pattern"; "g")` instead — explicit newline alternation behaves reliably. See `enforce-insight-publish.sh` for a working example.
+
+**"No-jq" tests: symlink `cat` + `bash` into a fake PATH, not an empty dir.** Every hook reads stdin via `cat`, which needs PATH to resolve before the `command -v jq` check runs. A truly empty PATH fails with `cat: command not found` (exit 127) before the graceful-degradation branch is reached. Fix:
+
+```bash
+local no_jq_dir="$TEST_TMP/no-jq"
+mkdir -p "$no_jq_dir"
+ln -sf "$(type -P cat)"  "$no_jq_dir/cat"
+ln -sf "$(type -P bash)" "$no_jq_dir/bash"
+PATH="$no_jq_dir" bash "$HOOKS_DIR/your-hook.sh"
+```
+
+Use `type -P`, not `command -v` — it bypasses shell aliases (your outer zsh may have `alias cat=bat` etc. that would break the symlink).
+
 ## Configuration
 
 In `settings.json`:

--- a/home/.claude/hooks/README.md
+++ b/home/.claude/hooks/README.md
@@ -273,10 +273,10 @@ local no_jq_dir="$TEST_TMP/no-jq"
 mkdir -p "$no_jq_dir"
 ln -sf "$(type -P cat)"  "$no_jq_dir/cat"
 ln -sf "$(type -P bash)" "$no_jq_dir/bash"
-PATH="$no_jq_dir" bash "$HOOKS_DIR/your-hook.sh"
+env -i PATH="$no_jq_dir" HOME="$HOME" bash "$HOOKS_DIR/your-hook.sh"
 ```
 
-Use `type -P`, not `command -v` — it bypasses shell aliases (your outer zsh may have `alias cat=bat` etc. that would break the symlink).
+`env -i` is load-bearing: without it, PATH inherits from the test shell, and on Debian/Ubuntu CI runners `/usr/bin/jq` would be found — the test then passes via an unrelated code path and masks regressions. Use `type -P`, not `command -v` — it bypasses shell aliases (your outer zsh may have `alias cat=bat` etc. that would break the symlink).
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

- **Hooks README**: new "Gotchas" subsection captures two jq/PATH traps rediscovered during PR #303 — the jq 1.8.1 multiline-anchor quirk (`scan("^..";"m")` unreliable; use `match("(?:^|\n)..";"g")`), and the cat+bash symlink requirement for no-jq test PATH stubbing. Future hook authors shouldn't rediscover these.
- **CLAUDE.md**: one-liner added to Proactive Improvements — prefer zero-runtime-cost shapes (memory, event bus, docs) over skill-prompt edits for low-trigger-rate fixes. Codifies the "don't bake niche logic into /work or /pr-create" lesson from the #301 reflection.

## Why

improve-workflow surfaced three findings after #301 merged. Finding #3 (hooks README additions) was the only one with favorable value-per-token — runtime cost is zero, benefit is concentrated on hook-authoring sessions. Findings #1 and #2 (skill edits) were deferred because they'd tax every invocation across all sessions for ~1% trigger rate. The CLAUDE.md one-liner encodes that shape-selection judgment itself.

Follow-ups from the same reflection that are **not** included here (intentionally):

- `/pr-create` live-validation checkpoint — already captured as memory + event-bus `improvement_suggested`. Revisit as standalone `/live-validate` skill if the pattern recurs.
- `/work` enforcement-gap classifier — same disposition.

## Test plan

- [x] `make check` passes (29/29 bootstrap tests; no shell changes so nothing to re-lint)
- [x] No new runtime behavior — docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)