### PR TITLE
chore: remove broken NTFS-write stack (mounty, macfuse, ntfs-3g-mac)

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -4,7 +4,6 @@
 
 # Taps
 tap "cormacrelf/tap"
-tap "gromgit/fuse"
 
 # CLI Tools
 brew "bat"                    # Cat with syntax highlighting
@@ -61,7 +60,6 @@ brew "whisper-cpp"              # Local speech-to-text
 brew "ffmpeg"
 brew "scc"                    # Code line counter
 brew "testdisk"               # Data recovery
-brew "gromgit/fuse/ntfs-3g-mac" # NTFS read-write support (requires macfuse)
 
 # Casks - Dev Tools
 cask "codex"
@@ -71,8 +69,6 @@ cask "lm-studio"
 # Casks - Apps
 cask "google-chrome"
 cask "iina"                   # Video player
-cask "macfuse"                 # FUSE filesystem support (pre-installed by bootstrap, required by ntfs-3g)
-cask "mounty"                  # NTFS re-mount in read-write
 cask "obsidian"               # Note-taking
 cask "spotify"
 cask "stats"                  # Menu bar system monitor

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -957,18 +957,6 @@ install_bat_themes() {
 	fi
 }
 
-install_brew_prereq_casks() {
-	# Some brew formulae depend on casks (e.g., ntfs-3g-mac requires macfuse).
-	# Homebrew Bundle installs all brews before casks, so we pre-install these.
-	local prereqs=("macfuse")
-	for cask in "${prereqs[@]}"; do
-		if ! brew list --cask "$cask" &>/dev/null; then
-			echo "Pre-installing cask dependency: $cask..."
-			brew install --cask "$cask"
-		fi
-	done
-}
-
 install_brew_packages() {
 	if ! command -v brew >/dev/null 2>&1; then
 		echo "Skipping Homebrew packages (brew not installed)"
@@ -982,8 +970,6 @@ install_brew_packages() {
 	if [[ ! -f "$brewfile" ]]; then
 		return 0
 	fi
-
-	install_brew_prereq_casks
 
 	echo "Installing Homebrew packages..."
 	# Use --adopt to take ownership of existing apps instead of erroring


### PR DESCRIPTION
## Summary

The whole FOSS NTFS read-write path stopped working when macOS 15 retired the legacy NTFS kext and moved to **fskit** (which is read-only by design). Specifically:

- **mounty's** remount-rw trick is now a silent no-op — it exploited an undocumented `rw` flag on the legacy NTFS kext that no longer exists in the fskit driver
- **ntfs-3g-mac** via **macfuse** is unsupported on Apple Silicon / recent macOS, even with workarounds
- **Paragon NTFS for Mac** (installed manually, license is paid) is now handling NTFS write access — confirmed working via the `ufsd_NTFS` filesystem driver

This PR removes the dead-weight stack from Brewfile + bootstrap.sh.

## Changes

- **Brewfile**
  - drop `cask "mounty"`
  - drop `cask "macfuse"`
  - drop `brew "gromgit/fuse/ntfs-3g-mac"`
  - drop `tap "gromgit/fuse"` (only existed for ntfs-3g-mac)
- **bootstrap.sh**
  - remove `install_brew_prereq_casks()` function (only existed to pre-install macfuse before brew bundle ran the ntfs-3g-mac formula)
  - remove its call site

## Test plan

- [x] `make check` — 29/29 passing
- [x] Local system already scrubbed (apps, prefs, brew Caskroom, DMG cache, macFUSE driver/prefPane via official uninstaller)
- [x] NTFS write confirmed working post-cleanup via `touch /Volumes/My\ Passport/...`
- [ ] CI green