### PR TITLE
chore: cleanup stale specs, normalize pwd -P, tweak settings

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -206,7 +206,7 @@ ensure_openclaw_workspace() {
 }
 
 symlink_openclaw_config() {
-	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 	local src_file="$dotfiles_dir/home/.openclaw/openclaw.json"
 	local dest_file="$HOME/.openclaw/openclaw.json"
 
@@ -370,7 +370,7 @@ install_tmux_plugin_manager() {
 install_launch_agent() {
 	local plist="$1"
 	local label="${plist%.plist}"
-	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 	local launch_agents_dir="$HOME/Library/LaunchAgents"
 
 	mkdir -p "$launch_agents_dir"
@@ -403,7 +403,7 @@ install_launch_agents() {
 		return 0
 	fi
 
-	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 	# Install dark-notify LaunchAgent (only if dark-notify is installed)
 	if command -v dark-notify >/dev/null 2>&1; then
@@ -788,7 +788,7 @@ install_linux_common_packages() {
 }
 
 install_packages() {
-	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 	if [[ "$(uname)" == "Darwin" ]]; then
 		# macOS - use Homebrew
@@ -876,7 +876,7 @@ update_packages() {
 }
 
 init_submodules() {
-	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 	# Check if any submodule is missing
 	if [[ -d "$dotfiles_dir/vendor/btop-catppuccin/themes" ]] && \
@@ -901,7 +901,7 @@ init_submodules() {
 
 install_btop_themes() {
 	local btop_themes_dir="$HOME/.config/btop/themes"
-	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 	local vendor_theme="$dotfiles_dir/vendor/btop-catppuccin/themes/catppuccin_mocha.theme"
 
 	if [[ ! -f "$vendor_theme" ]]; then
@@ -924,7 +924,7 @@ install_btop_themes() {
 
 install_bat_themes() {
 	local bat_themes_dir="$HOME/.config/bat/themes"
-	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 	local vendor_theme="$dotfiles_dir/vendor/bat-catppuccin/themes/Catppuccin Mocha.tmTheme"
 
 	if [[ ! -f "$vendor_theme" ]]; then
@@ -964,7 +964,7 @@ install_brew_packages() {
 		return 0
 	fi
 
-	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 	local brewfile="$dotfiles_dir/Brewfile"
 
 	if [[ ! -f "$brewfile" ]]; then
@@ -987,7 +987,7 @@ install_brew_packages() {
 }
 
 run_brew_hooks() {
-	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 	local hooks_dir="$dotfiles_dir/brew-hooks"
 
 	if [[ ! -d "$hooks_dir" ]]; then
@@ -1003,7 +1003,7 @@ run_brew_hooks() {
 
 install_eza_theme() {
 	local eza_config_dir="$HOME/.config/eza"
-	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 	local vendor_theme="$dotfiles_dir/vendor/eza-catppuccin/themes/mocha/catppuccin-mocha-mauve.yml"
 
 	if [[ ! -f "$vendor_theme" ]]; then
@@ -1025,7 +1025,7 @@ install_eza_theme() {
 
 install_glamour_theme() {
 	local glamour_dir="$HOME/.config/glamour"
-	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	local dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 	local vendor_theme="$dotfiles_dir/vendor/glamour-catppuccin/themes/catppuccin-mocha.json"
 
 	if [[ ! -f "$vendor_theme" ]]; then

--- a/brew-hooks/iterm2.sh
+++ b/brew-hooks/iterm2.sh
@@ -8,7 +8,7 @@ if [[ ! -d "/Applications/iTerm.app" ]]; then
 	exit 0
 fi
 
-dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+dotfiles_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 profile_src="$dotfiles_dir/preferences/iTerm Profile.json"
 dynamic_profiles_dir="$HOME/Library/Application Support/iTerm2/DynamicProfiles"
 

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -134,5 +134,8 @@
     "frontend-design@claude-plugins-official": true
   },
   "fastMode": true,
-  "skipDangerousModePermissionPrompt": true
+  "skipDangerousModePermissionPrompt": true,
+  "theme": "auto",
+  "remoteControlAtStartup": true,
+  "agentPushNotifEnabled": true
 }

--- a/home/.claude/skills/shell-scripting/SKILL.md
+++ b/home/.claude/skills/shell-scripting/SKILL.md
@@ -82,12 +82,12 @@ fi
 
 ## Paths
 
-Resolve symlinks when capturing the script's own location — use `pwd -P`, not `pwd`. Plain `pwd` returns the logical path, so a script run via a symlink ends up with a directory string that doesn't match its physical location. If any subsequent code does a same-path guard (`[ "$src" = "$dest" ]`), it fails to fire and the script can overwrite its own source.
+Resolve symlinks when capturing the script's own location — use `pwd -P`, not `pwd`. Plain `pwd` returns the logical path, so a script run via a symlink ends up with a directory string that doesn't match its physical location. If any subsequent code does a same-path guard (`[[ "$src" == "$dest" ]]`), it fails to fire and the script can overwrite its own source.
 
 ```bash
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 dest_dir="$(cd "$(dirname "$dest_file")" && pwd -P)"
-[ "$script_dir" = "$dest_dir" ] && return  # same file, skip
+[[ "$script_dir" == "$dest_dir" ]] && return  # same file, skip
 ```
 
 ## Variables

--- a/home/.claude/skills/shell-scripting/SKILL.md
+++ b/home/.claude/skills/shell-scripting/SKILL.md
@@ -80,6 +80,16 @@ if ! command -v foo &>/dev/null; then
 fi
 ```
 
+## Paths
+
+Resolve symlinks when capturing the script's own location — use `pwd -P`, not `pwd`. Plain `pwd` returns the logical path, so a script run via a symlink ends up with a directory string that doesn't match its physical location. If any subsequent code does a same-path guard (`[ "$src" = "$dest" ]`), it fails to fire and the script can overwrite its own source.
+
+```bash
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+dest_dir="$(cd "$(dirname "$dest_file")" && pwd -P)"
+[ "$script_dir" = "$dest_dir" ] && return  # same file, skip
+```
+
 ## Variables
 
 - Quote all variable expansions: `"$var"`, `"${var}"`, `"$@"`

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 BOOTSTRAP="$SCRIPT_DIR/../bootstrap.sh"
 
 # Test counters

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 HOOKS_DIR="$SCRIPT_DIR/../home/.claude/hooks"
 
 # Test counters

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Uninstall Script - Remove Dotfiles
 # ==============================================================================
 
-DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 # Find all symlinks pointing to this repo
 SYMLINKS=()


### PR DESCRIPTION
## Summary

Three small, related cleanups bundled into one PR.

### 1. Delete stale spec docs + AGENTS.md
Removed (untracked, so they don't appear in the diff):
- `docs/PR_CREATE_TOOL_SPEC.md`, `docs/PR_REVIEW_TOOL_SPEC.md`, `docs/CI_WATCH_TOOL_SPEC.md` — features already shipped as Claude Code skills.
- `docs/AUTO_MERGE_SPEC.md` — never implemented, ~2 months stale.
- `AGENTS.md` — its branch-before-commit rule duplicates the global CLAUDE.md / memory; its `pwd -P` rule moved into the `shell-scripting` skill (better trigger: auto-applies on `.sh` edits).

### 2. Normalize `pwd` → `pwd -P` across all shell scripts
`bootstrap.sh` was internally inconsistent — 4 functions used `pwd -P`, ~15 used plain `pwd`. Normalized 15 occurrences across:
- `bootstrap.sh` (11x)
- `uninstall.sh`, `brew-hooks/iterm2.sh`, `tests/test-bootstrap.sh`, `tests/test-hooks.sh` (1x each)

No active bug today — existing same-path guards compare `readlink` strings rather than `cd`/`pwd` output. But normalization closes the gap before a future refactor reintroduces the self-overwrite risk.

### 3. settings.json tweaks
Three recent `/config` toggles worth tracking across machines: `theme=auto`, `remoteControlAtStartup=true`, `agentPushNotifEnabled=true`.

## Test plan

- [x] `make lint` — shellcheck clean
- [x] `make test` — bash/zsh syntax
- [x] `make test-bootstrap` — 29/29 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)