### PR TITLE
fix: cache zellij sysload via launchd; stop pane-frame flicker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ Files in `home/` are symlinked to `~` by `bootstrap.sh`. This allows version con
 
 **OpenClaw** (`home/.openclaw/`) - Personal AI assistant gateway. Client config is tracked; gateway host (mac-mini) keeps its own. Bootstrap handles setup — just add `OPENCLAW_GATEWAY_TOKEN` to `~/.extra`.
 
-**Zellij** (`home/.config/zellij/`) - Terminal multiplexer config with Catppuccin Mocha theme, zjstatus bar, autolock plugin. Swap layouts in `default.swap.kdl`. Config changes require killing the session (`zellij kill-all-sessions`) — hot-reload doesn't work with symlinked configs (zellij-org/zellij#3992).
+**Zellij** (`home/.config/zellij/`) - Terminal multiplexer config with Catppuccin Mocha theme, zjstatus bar, autolock plugin. Swap layouts in `default.swap.kdl`. Config changes require killing the session (`zellij kill-all-sessions`) — hot-reload doesn't work with symlinked configs (zellij-org/zellij#3992). The sysload widget reads from `~/.cache/sysload`, populated by the `com.evansenter.sysload` LaunchAgent every 10s — zjstatus's `command_*` widgets spawn per zjstatus-plugin-instance (one per tab), so calling `top` synchronously inside the widget piles up under load and causes pane-frame flicker via `hide_frame_for_single_pane`.
 
 **Statusline** (`home/.claude/statusline-command.sh`) - Custom statusline for Claude Code.
 - Format: `[repo/session]:branch ✓/✗/↻ →#issues ● model context%` (CI status hidden when dirty)

--- a/LaunchAgents/com.evansenter.sysload.plist
+++ b/LaunchAgents/com.evansenter.sysload.plist
@@ -24,5 +24,8 @@
 
     <key>ProcessType</key>
     <string>Background</string>
+
+    <key>Nice</key>
+    <integer>10</integer>
 </dict>
 </plist>

--- a/LaunchAgents/com.evansenter.sysload.plist
+++ b/LaunchAgents/com.evansenter.sysload.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.evansenter.sysload</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__HOME__/.bin/sysload-writer</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StartInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/.local/log/sysload.out</string>
+
+    <key>StandardErrorPath</key>
+    <string>__HOME__/.local/log/sysload.err</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -451,6 +451,13 @@ install_launch_agents() {
 	if [[ "${HOSTNAME%%.*}" == "mac-mini" ]] && command -v obsidian-mcp-server >/dev/null 2>&1; then
 		install_launch_agent "com.evansenter.obsidian-mcp.plist"
 	fi
+
+	# Install sysload writer LaunchAgent (only if zellij is installed)
+	# Caches `top` output to ~/.cache/sysload every 10s so the zjstatus
+	# sysload widget can read it without spawning `top` per-tab-per-redraw.
+	if command -v zellij >/dev/null 2>&1; then
+		install_launch_agent "com.evansenter.sysload.plist"
+	fi
 }
 
 cleanup_legacy_cron() {

--- a/home/.bin/sysload-writer
+++ b/home/.bin/sysload-writer
@@ -8,13 +8,20 @@ set -u
 CACHE="$HOME/.cache/sysload"
 mkdir -p "$(dirname "$CACHE")"
 
-output=$(top -l 1 -s 0 2>/dev/null) || exit 0
+# Don't swallow top's stderr: a failure here should land in ~/.local/log/sysload.err
+# (wired by the LaunchAgent) rather than silently freezing the widget on stale data.
+output=$(top -l 1 -s 0) || exit 0
 cpu=$(echo "$output" | awk '/CPU usage/ { printf "%d%%", 100 - $7 }')
 mem=$(echo "$output" | awk '/PhysMem/ {
     # Format: "PhysMem: 20G used (2759M wired, 3222M compressor), 2949M unused."
-    # $2 = total used, $8 = unused. $6 is compressor (already counted as used).
-    used = $2; unused = $8
-    if (index(used,"G")) { u = used * 1024 } else { u = used + 0 }
+    # Match by keyword, not field position: the compressor parenthetical is optional
+    # on older macOS, which would shift positional indices. "used"/"unused." each
+    # follow their value field.
+    for (i = 2; i <= NF; i++) {
+        if ($i == "used")        used   = $(i-1)
+        else if ($i ~ /^unused/) unused = $(i-1)
+    }
+    if (index(used,"G"))   { u = used * 1024 }   else { u = used + 0 }
     if (index(unused,"G")) { f = unused * 1024 } else { f = unused + 0 }
     if (u + f > 0) printf "%d%%", (u / (u + f)) * 100
 }')

--- a/home/.bin/sysload-writer
+++ b/home/.bin/sysload-writer
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Writes macOS system load (CPU% + RAM%) to ~/.cache/sysload.
+# Run periodically by com.evansenter.sysload LaunchAgent; the zellij
+# zjstatus sysload widget reads the cache. See dotfiles CLAUDE.md
+# "Zellij" section for why this isn't called synchronously from zjstatus.
+set -u
+
+CACHE="$HOME/.cache/sysload"
+mkdir -p "$(dirname "$CACHE")"
+
+output=$(top -l 1 -s 0 2>/dev/null) || exit 0
+cpu=$(echo "$output" | awk '/CPU usage/ { printf "%d%%", 100 - $7 }')
+mem=$(echo "$output" | awk '/PhysMem/ {
+    # Format: "PhysMem: 20G used (2759M wired, 3222M compressor), 2949M unused."
+    # $2 = total used, $8 = unused. $6 is compressor (already counted as used).
+    used = $2; unused = $8
+    if (index(used,"G")) { u = used * 1024 } else { u = used + 0 }
+    if (index(unused,"G")) { f = unused * 1024 } else { f = unused + 0 }
+    if (u + f > 0) printf "%d%%", (u / (u + f)) * 100
+}')
+
+{ [ -z "$cpu" ] || [ -z "$mem" ]; } && exit 0
+
+tmp="$CACHE.tmp.$$"
+printf '󰒼 %s  󰍛 %s' "$cpu" "$mem" > "$tmp"
+mv -f "$tmp" "$CACHE"

--- a/home/.config/btop/btop.conf
+++ b/home/.config/btop/btop.conf
@@ -1,4 +1,4 @@
-#? Config file for btop v.1.4.6
+#? Config file for btop v.1.4.7
 
 #* Name of a btop++/bpytop/bashtop formatted ".theme" file, "Default" and "TTY" for builtin themes.
 #* Themes should be placed in "../share/btop/themes" relative to binary or "$HOME/.config/btop/themes"
@@ -14,6 +14,11 @@ truecolor = true
 #* Will force 16-color mode and TTY theme, set all graph symbols to "tty" and swap out other non tty friendly symbols.
 force_tty = false
 
+#* Option to disable presets. Either the default preset, custom presets, or all presets.
+#* "Off" All presets are enabled.
+#* "Default" preset is disabled.#* "Custom" presets are disabled.#* "All" presets are disabled.
+disable_presets = "Off"
+
 #* Define presets for the layout of the boxes. Preset 0 is always all boxes shown with default settings. Max 9 presets.
 #* Format: "box_name:P:G,box_name:P:G" P=(0 or 1) for alternate positions, G=graph symbol to use for box.
 #* Use whitespace " " as separator between different presets.
@@ -23,6 +28,9 @@ presets = "cpu:1:default,proc:0:default cpu:0:default,mem:0:default,net:0:defaul
 #* Set to True to enable "h,j,k,l,g,G" keys for directional control in lists.
 #* Conflicting keys for h:"help" and k:"kill" is accessible while holding shift.
 vim_keys = true
+
+#* Disable all mouse events.
+disable_mouse = false
 
 #* Rounded corners on boxes, is ignored if TTY mode is ON.
 rounded_corners = true
@@ -39,6 +47,9 @@ graph_symbol = "braille"
 
 # Graph symbol to use for graphs in cpu box, "default", "braille", "block" or "tty".
 graph_symbol_cpu = "default"
+
+# Graph symbol to use for graphs in gpu box, "default", "braille", "block" or "tty".
+graph_symbol_gpu = "default"
 
 # Graph symbol to use for graphs in cpu box, "default", "braille", "block" or "tty".
 graph_symbol_mem = "default"
@@ -89,6 +100,9 @@ proc_left = false
 #* (Linux) Filter processes tied to the Linux kernel(similar behavior to htop).
 proc_filter_kernel = false
 
+#* Should the process list follow the selected process when detailed view is open.
+proc_follow_detailed = true
+
 #* In tree-view, always accumulate child process resources in the parent process.
 proc_aggregate = false
 
@@ -102,6 +116,9 @@ cpu_graph_upper = "Auto"
 #* Sets the CPU stat shown in lower half of the CPU graph, "total" is always available.
 #* Select from a list of detected attributes from the options menu.
 cpu_graph_lower = "Auto"
+
+#* If gpu info should be shown in the cpu box. Available values = "Auto", "On" and "Off".
+show_gpu_info = "Auto"
 
 #* Toggles if the lower CPU graph should be inverted.
 cpu_invert_lower = true
@@ -199,6 +216,9 @@ io_graph_combined = false
 #* Example: "/mnt/media:100 /:20 /boot:1".
 io_graph_speeds = ""
 
+#* Swap the positions of the upload and download speed graphs. When true, upload will be on top.
+swap_upload_download = false
+
 #* Set fixed values for network graphs in Mebibits. Is only used if net_auto is also set to False.
 net_download = 100
 
@@ -231,3 +251,33 @@ log_level = "WARNING"
 
 #* Automatically save current settings to config file on exit.
 save_config_on_exit = true
+
+#* Measure PCIe throughput on NVIDIA cards, may impact performance on certain cards.
+nvml_measure_pcie_speeds = true
+
+#* Measure PCIe throughput on AMD cards, may impact performance on certain cards.
+rsmi_measure_pcie_speeds = true
+
+#* Horizontally mirror the GPU graph.
+gpu_mirror_graph = true
+
+#* Set which GPU vendors to show. Available values are "nvidia amd intel apple"
+shown_gpus = "nvidia amd intel apple"
+
+#* Custom gpu0 model name, empty string to disable.
+custom_gpu_name0 = ""
+
+#* Custom gpu1 model name, empty string to disable.
+custom_gpu_name1 = ""
+
+#* Custom gpu2 model name, empty string to disable.
+custom_gpu_name2 = ""
+
+#* Custom gpu3 model name, empty string to disable.
+custom_gpu_name3 = ""
+
+#* Custom gpu4 model name, empty string to disable.
+custom_gpu_name4 = ""
+
+#* Custom gpu5 model name, empty string to disable.
+custom_gpu_name5 = ""

--- a/home/.config/zellij/layouts/default.kdl
+++ b/home/.config/zellij/layouts/default.kdl
@@ -43,7 +43,10 @@ layout {
                 format_precedence "lrc"
 
                 border_enabled  "false"
-                hide_frame_for_single_pane "true"
+                // hide_frame_for_single_pane sends a TogglePaneFrame IPC to zellij
+                // on each bar redraw; with pane_frames=true that causes visible flicker
+                // even on a stable system. Leaving frames always-on instead.
+                hide_frame_for_single_pane "false"
 
                 // -- Mode indicator (powerline style) --
                 mode_normal       "#[bg=$green,fg=$crust,bold]  NORMAL #[bg=$surface0,fg=$green]"

--- a/home/.config/zellij/scripts/sysload.sh
+++ b/home/.config/zellij/scripts/sysload.sh
@@ -1,12 +1,7 @@
 #!/bin/bash
-# macOS system load: CPU% + RAM%
-output=$(top -l 1 -s 0 2>/dev/null)
-cpu=$(echo "$output" | awk '/CPU usage/ { printf "%d%%", 100 - $7 }')
-mem=$(echo "$output" | awk '/PhysMem/ {
-    used = $2; unused = $6
-    # Strip G/M suffix and normalize to MB
-    if (index(used,"G")) { u = used * 1024 } else { u = used + 0 }
-    if (index(unused,"G")) { f = unused * 1024 } else { f = unused + 0 }
-    printf "%d%%", (u / (u + f)) * 100
-}')
-[ -n "$cpu" ] && printf '󰒼 %s  󰍛 %s' "$cpu" "$mem"
+# Print cached system load for the zjstatus sysload widget.
+# Cache is populated by the com.evansenter.sysload LaunchAgent every 10s
+# (~/.bin/sysload-writer). Synchronous `top` here would stack up under load
+# because zjstatus spawns command widgets per tab — see CLAUDE.md.
+CACHE="$HOME/.cache/sysload"
+[ -s "$CACHE" ] && cat "$CACHE"

--- a/home/.config/zellij/scripts/sysload.sh
+++ b/home/.config/zellij/scripts/sysload.sh
@@ -4,4 +4,8 @@
 # (~/.bin/sysload-writer). Synchronous `top` here would stack up under load
 # because zjstatus spawns command widgets per tab — see CLAUDE.md.
 CACHE="$HOME/.cache/sysload"
-[ -s "$CACHE" ] && cat "$CACHE"
+# Blank the widget if the writer LaunchAgent has gone silent (cache older than
+# ~2min) so an outage is visible instead of showing forever-stale numbers.
+if [ -s "$CACHE" ] && find "$CACHE" -mmin -2 2>/dev/null | grep -q .; then
+    cat "$CACHE"
+fi

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -142,9 +142,5 @@ fi
 # Antigravity
 export PATH="$HOME/.antigravity/antigravity/bin:$PATH"
 
-
-# Added by Antigravity CLI installer
-export PATH="/Users/evansenter/.local/bin:$PATH"
-
-# Added by Antigravity IDE
-export PATH="/Users/evansenter/.antigravity-ide/antigravity-ide/bin:$PATH"
+# Antigravity IDE (installer's ~/.local/bin export omitted — .exports already adds it)
+export PATH="$HOME/.antigravity-ide/antigravity-ide/bin:$PATH"

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -141,3 +141,10 @@ fi
 
 # Antigravity
 export PATH="$HOME/.antigravity/antigravity/bin:$PATH"
+
+
+# Added by Antigravity CLI installer
+export PATH="/Users/evansenter/.local/bin:$PATH"
+
+# Added by Antigravity IDE
+export PATH="/Users/evansenter/.antigravity-ide/antigravity-ide/bin:$PATH"


### PR DESCRIPTION
## Summary
- zjstatus's per-tab `command_*` spawning made `sysload.sh` pile up `top` invocations under load (observed 300+ stacked processes, `top` runtime 17.4s vs 0.5s normal, CPU pegged). Moves `top` into a launchd job with at-most-one-in-flight semantics; widget just `cat`s the cache (`~/.cache/sysload`).
- Disables `hide_frame_for_single_pane` — its per-redraw TogglePaneFrame IPC causes visible pane-frame flicker even on a stable system. Single-pane tabs now show a frame.
- Fixes a pre-existing awk field bug in the PhysMem parser (`$6` was reading compressor, should be `$8` = unused). Caused the memory% gauge to under-report precisely under memory pressure. Adds a divide-by-zero guard for malformed top output.
- Bundles drift: btop v1.4.7 auto-upgrade and Antigravity installer's PATH additions to `.zshrc`.

## Test plan
- [x] `make check` — 88+29 tests pass
- [x] `shellcheck` clean on `sysload-writer` and `sysload.sh`
- [x] LaunchAgent loads + ticks (verified `launchctl list`, cache repopulates within 10s after deletion)
- [x] Memory math verified against real `top` output on Darwin 25.5.0
- [ ] After merge: `./bootstrap.sh -f` on other macOS hosts; confirm `com.evansenter.sysload` loads and `~/.cache/sysload` populates
- [ ] After merge: leave zellij open with many tabs under sustained load; confirm no process pile-up returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)