### PR TITLE
fix: pre-flight Obsidian REST healthcheck in obsidian-mcp-start

### DIFF
--- a/home/.bin/obsidian-mcp-start
+++ b/home/.bin/obsidian-mcp-start
@@ -22,4 +22,16 @@ export MCP_HTTP_HOST="127.0.0.1"
 export OBSIDIAN_BASE_URL="${OBSIDIAN_BASE_URL:-https://127.0.0.1:27124}"
 export OBSIDIAN_VERIFY_SSL="${OBSIDIAN_VERIFY_SSL:-false}"
 
+# Pre-flight: obsidian-mcp-server is useless unless the Obsidian Local REST API
+# is reachable. That API only listens while the Obsidian GUI app is running, so
+# if Obsidian is closed the server would start, fail every request, and exit --
+# and launchd's KeepAlive would restart it in a tight loop. Instead, probe the
+# upstream first; if it's down, sleep and exit non-zero so launchd's
+# ThrottleInterval backs off and retries calmly until Obsidian is up again.
+if ! curl -sk --max-time 5 -o /dev/null "$OBSIDIAN_BASE_URL"; then
+	echo "Obsidian REST API not reachable at $OBSIDIAN_BASE_URL; is the Obsidian app running? Backing off." >&2
+	sleep 15
+	exit 1
+fi
+
 exec obsidian-mcp-server


### PR DESCRIPTION
## What

Add a pre-flight upstream healthcheck to `home/.bin/obsidian-mcp-start` (the LaunchAgent wrapper for `obsidian-mcp-server`).

## Why

`obsidian-mcp-server` binds `127.0.0.1:3010` and proxies to the **Obsidian Local REST API** plugin on `127.0.0.1:27124`. That REST API only listens **while the Obsidian GUI app is running**.

When Obsidian is closed (reboot, quit, crash), the chain failed like this:

```
request -> obsidian-mcp-server -> REST API :27124 (down)
        -> 500 / ERR_HTTP_HEADERS_SENT flood -> process exits 1
        -> launchd KeepAlive restarts immediately -> repeat
```

Observed `runs = 18616` with `last exit code = 1` — a restart-storm. Externally this presents as a fast `502` at the `tailscale serve` front door, indistinguishable from a dead service, which made the missing-dependency root cause hard to spot.

## How

Before `exec obsidian-mcp-server`, curl the REST API. If it's unreachable: log a clear message, `sleep 15`, and `exit 1` so launchd's `ThrottleInterval` (30s) backs off calmly until Obsidian is up — instead of hot-looping on a guaranteed crash.

## Verification

- **Upstream down** (`OBSIDIAN_BASE_URL=https://127.0.0.1:9`): exit `1` after ~15s, server **not** started, one `Backing off` line logged.
- **Upstream up**: server starts, binds `:3010`, and `POST https://mac-mini.tailac7b3c.ts.net/obsidian-mcp/mcp` returns `200` with `serverInfo: obsidian-mcp-server v2.0.7`; `claude mcp list` shows ✓ Connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
