### PR TITLE
audit: new-machine readiness fixes (bootstrap, statusline, hooks, workflow, docs, tests)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,11 +115,13 @@ Files in `home/` are symlinked to `~` by `bootstrap.sh`. This allows version con
 | agent-memory-store | 8083 | `/agent-memory-store` | `com.evansenter.agent-memory-store` |
 | obsidian-mcp | 3010 | `/obsidian-mcp` | `com.evansenter.obsidian-mcp` |
 
-LaunchAgent plists live in `~/Library/LaunchAgents/`. Each service repo has `make install-server` to set up. Reload with `launchctl unload` + `launchctl load`. The obsidian-mcp LaunchAgent is managed by this repo (plist in `LaunchAgents/`, wrapper in `home/.bin/obsidian-mcp-start`). Requires Obsidian with the Local REST API plugin running.
+LaunchAgent plists live in `~/Library/LaunchAgents/`. The external service repos (event-bus, session-analytics, memory-store) have their own `make install-server`; obsidian-mcp is set up by *this* repo's bootstrap (`claude mcp add` + plist in `LaunchAgents/`, wrapper in `home/.bin/obsidian-mcp-start`, requires Obsidian with the Local REST API plugin running). Reload with `launchctl unload` + `launchctl load`.
+
+Note: `agent-memory-store` is documented infra but is **not** provisioned by bootstrap (no `claude mcp add`, no `AGENT_MEMORY_STORE_URL` in `settings.local.json`) — it's registered out-of-band where used. The repo-managed LaunchAgents are: `com.evansenter.obsidian-mcp` (gateway only), `com.evansenter.sysload` (zellij CPU/RAM widget, if zellij installed), `com.user.dark-notify` (btop dark-mode switching, if dark-notify installed), and `com.user.cargo-sweep` (periodic `cargo sweep`, if cargo installed).
 
 **Adding new LaunchAgents:** Plists go in the top-level `LaunchAgents/` directory (NOT `home/Library/LaunchAgents/`). Use `__HOME__` as a placeholder for the user's home directory — `install_launch_agent()` in bootstrap does `sed` substitution at install time. Logs go to `~/.local/log/`. Add an `install_launch_agent` call in `install_launch_agents()`, gated on the binary being present.
 
-**Host-gating:** Services that only run on mac-mini (LaunchAgents, npm installs for server-side packages) must be gated with `[[ "${HOSTNAME%%.*}" == "mac-mini" ]]`. Remote machines should only get MCP registration pointing at the Tailscale URL. The `GATEWAY_HOST` constant at the top of bootstrap.sh holds the Tailscale hostname.
+**Host-gating:** Services that only run on mac-mini (LaunchAgents, npm installs for server-side packages) must be gated with the `is_gateway_host` helper in bootstrap.sh. It matches `^mac-mini(-[0-9]+)?$`, so the gate still holds if macOS Bonjour appends a `-N` LocalHostName suffix on an mDNS collision (e.g. `mac-mini-2`) — a bare `== "mac-mini"` match silently fails there and the gateway stops behaving as the gateway. Remote machines should only get MCP registration pointing at the Tailscale URL. The `GATEWAY_HOST` constant at the top of bootstrap.sh holds the Tailscale hostname.
 
 **Important:** Never place projects in `~/Documents/` — macOS TCC blocks LaunchAgents from accessing it, causing silent `PermissionError` failures.
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ test:
 	@echo "Checking bash syntax..."
 	@bash -n bootstrap.sh
 	@bash -n uninstall.sh
+	@for f in home/.bin/*; do echo "  $$f"; bash -n "$$f" || exit 1; done
 	@echo "Checking zsh syntax..."
 	@zsh -n home/.zshrc
 	@zsh -n home/.aliases

--- a/README.md
+++ b/README.md
@@ -112,9 +112,11 @@ brew install cormacrelf/tap/dark-notify
 ./bootstrap.sh  # Symlinks commands/, hooks/, settings.json, CLAUDE.md
 ```
 
-Also installs GitHub MCP server and enables plugins (feature-dev, pr-review-toolkit, commit-commands, code-simplifier, LSP integrations). Set `GITHUB_TOKEN` in `~/.extra`:
+Also installs the GitHub MCP server and enables a curated set of official plugins (see `enabledPlugins` in `home/.claude/settings.json`). Several integrations read secrets from `~/.extra` (not tracked):
 ```bash
-export GITHUB_TOKEN="ghp_your_token_here"
+export GITHUB_TOKEN="ghp_your_token_here"   # GitHub MCP / gh
+export OPENCLAW_GATEWAY_TOKEN="..."         # OpenClaw gateway client
+export OBSIDIAN_API_KEY="..."               # obsidian-mcp (gateway host only; wrapper exits without it)
 ```
 
 ## Updating

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -23,6 +23,13 @@ is_steamos() {
 	[[ -f /etc/os-release ]] && grep -q '^ID=steamos' /etc/os-release
 }
 
+# Returns 0 on the gateway host (mac-mini). Tolerates the macOS Bonjour "-N"
+# LocalHostName suffix appended on mDNS name collisions (e.g. "mac-mini-2"),
+# which a bare `== "mac-mini"` match would silently fail. See event-bus gotcha-4099.
+is_gateway_host() {
+	[[ "${HOSTNAME%%.*}" =~ ^mac-mini(-[0-9]+)?$ ]]
+}
+
 set_default_shell() {
 	local zsh_path
 	zsh_path="$(command -v zsh 2>/dev/null)" || return 0
@@ -305,7 +312,7 @@ configure_claude_local_settings() {
 	local settings_local="$HOME/.claude/settings.local.json"
 
 	# Skip if this is the gateway host (services run locally)
-	if [[ "${HOSTNAME%%.*}" == "mac-mini" ]]; then
+	if is_gateway_host; then
 		return 0
 	fi
 
@@ -391,7 +398,7 @@ install_launch_agent() {
 
 		# Reload the agent
 		launchctl bootout "gui/$(id -u)/$label" 2>/dev/null || true
-		launchctl bootstrap "gui/$(id -u)" "$dest_plist"
+		launchctl bootstrap "gui/$(id -u)" "$dest_plist" || true
 	else
 		rm -f "$tmp_plist"
 	fi
@@ -431,7 +438,7 @@ install_launch_agents() {
 			mv "$tmp_plist" "$dest_plist"
 
 			launchctl bootout "gui/$(id -u)/com.user.dark-notify" 2>/dev/null || true
-			launchctl bootstrap "gui/$(id -u)" "$dest_plist"
+			launchctl bootstrap "gui/$(id -u)" "$dest_plist" || true
 
 			"$HOME/.bin/toggle-btop-theme"
 		else
@@ -448,7 +455,7 @@ install_launch_agents() {
 	fi
 
 	# Install Obsidian MCP LaunchAgent (only on gateway host where the server runs)
-	if [[ "${HOSTNAME%%.*}" == "mac-mini" ]] && command -v obsidian-mcp-server >/dev/null 2>&1; then
+	if is_gateway_host && command -v obsidian-mcp-server >/dev/null 2>&1; then
 		install_launch_agent "com.evansenter.obsidian-mcp.plist"
 	fi
 }
@@ -1115,7 +1122,7 @@ install_claude_mcp_servers() {
 
 	# Install Obsidian MCP server if not configured
 	if ! echo "$mcp_list" | grep -q "obsidian"; then
-		if [[ "${HOSTNAME%%.*}" == "mac-mini" ]]; then
+		if is_gateway_host; then
 			install_npm_package "obsidian-mcp-server" "Obsidian MCP Server"
 			claude mcp add --transport http -s user obsidian http://localhost:3010/mcp
 

--- a/home/.aliases
+++ b/home/.aliases
@@ -37,7 +37,7 @@ fi
 
 alias lg="lazygit"
 alias zj="zellij"
-alias claude-yolo="claude --dangerously-skip-permissions"
+alias ccyolo="claude --dangerously-skip-permissions"
 
 # ==============================================================================
 # Git

--- a/home/.claude/agents/audit-workflows.md
+++ b/home/.claude/agents/audit-workflows.md
@@ -50,9 +50,9 @@ Analyze `.md` files in:
 
 Cross-check consistency within groups:
 - **Work flow**: /work, /pr-create, /pr-review, /watch-ci
-- **Audits**: /audit-codebase, /audit-tests, /audit-issues, /audit-workflows
-- **Coordination**: /parallel-work, /broadcast, /event-bus-status
-- **RFC**: /rfc-create, /rfc-respond
+- **Audits** (agents, via Task): audit-codebase, audit-tests, audit-issues, audit-workflows
+- **Coordination** (commands): /parallel-work, /broadcast, /event-bus-status
+- **RFC** (agents, via Task): rfc-create, rfc-respond
 
 ## Process
 
@@ -127,7 +127,7 @@ Options for each:
 
 - **Implement**: Make the fix using Edit tool
 - **Skip**: Record as skipped in final summary
-- **Defer**: Create issue with `gh issue create --label "docs"`
+- **Defer**: Create issue with `gh issue create --label "docs"` (pass title/body via `--body-file -` + heredoc; bracketed titles and markdown shell-evaluate under a bare `--body`/`--title "..."`)
 
 ### 5. Final Summary
 

--- a/home/.claude/agents/improve-workflow.md
+++ b/home/.claude/agents/improve-workflow.md
@@ -157,7 +157,7 @@ Save novel, cross-session insights to the project memory system. Only save thing
 For each finding with a concrete fix, use AskUserQuestion:
 - **Implement**: Make the change now
 - **Skip**: Move on
-- **Defer**: Create issue with `gh issue create --title "DX: [finding]" --label "improvement"`
+- **Defer**: Create issue with `gh issue create --label "improvement"`, passing the title and body via `--body-file -` + a heredoc — a bare `--title "DX: [finding]"` shell-evaluates the `[finding]` brackets.
 
 Only broadcast to event bus if you discovered something novel and actionable.
 

--- a/home/.claude/agents/rfc-create.md
+++ b/home/.claude/agents/rfc-create.md
@@ -85,7 +85,7 @@ Required: exactly one `priority:high/medium/low` label. Add relevant type labels
 
 ### 6. Create or Present
 
-**If `--post` flag**: Create immediately with `gh issue create`.
+**If `--post` flag**: Create immediately with `gh issue create` (pass the body via `--body-file -` + a single-quoted heredoc so markdown tables/`[refs]`/parens aren't shell-evaluated).
 
 **Otherwise**: Display the complete draft RFC, ask "Create this RFC?" via AskUserQuestion.
 

--- a/home/.claude/agents/rfc-respond.md
+++ b/home/.claude/agents/rfc-respond.md
@@ -80,7 +80,7 @@ Before posting, use AskUserQuestion for blocking decisions (max 4 at a time). In
 
 Incorporate decisions into the response, updating blocking/requirements sections.
 
-**If `--post` flag**: Post with `gh issue comment` and broadcast.
+**If `--post` flag**: Post with `gh issue comment` (body via `--body-file -` + single-quoted heredoc, so `[Question]`/parens/tables aren't shell-evaluated) and broadcast.
 
 **Otherwise**: Display final response and ask "Post this response?" via AskUserQuestion.
 

--- a/home/.claude/agents/status-report.md
+++ b/home/.claude/agents/status-report.md
@@ -78,7 +78,7 @@ mcp__agent-event-bus__get_events(limit=10)
 
 #### Important
 
-**Run `/audit-issues`**
+**Run the `audit-issues` agent** (via Task)
 - Evidence: N issues missing priority labels
 - Action: Triage and label backlog
 
@@ -90,7 +90,7 @@ mcp__agent-event-bus__get_events(limit=10)
 
 **Review permission gaps**
 - Evidence: `some-command` used N times without approval
-- Action: `/improve-workflow`
+- Action: run the `improve-workflow` agent (via Task)
 
 ## Broadcast
 

--- a/home/.claude/agents/summarize-work.md
+++ b/home/.claude/agents/summarize-work.md
@@ -124,4 +124,4 @@ If stale/missing, use AskUserQuestion: "Post summary to PR #N?" with "Post (Reco
 
 ### 4. Post Summary
 
-If approved, use `gh pr comment` with "## Work Summary" header as marker for future staleness detection.
+If approved, use `gh pr comment` with "## Work Summary" header as marker for future staleness detection. Pass the body via `--body-file -` and a single-quoted heredoc — a bare `--body "..."` lets the shell evaluate `[[`, `==`, and parens in the markdown.

--- a/home/.claude/commands/pr-review.md
+++ b/home/.claude/commands/pr-review.md
@@ -32,8 +32,11 @@ Output 2-3 sentence summary of what changed and why.
 
 ### 2. Run Analysis
 
+`code-reviewer` is an agent, not a skill — invoke it with the Task tool:
+
 ```
-Skill(pr-review-toolkit:code-reviewer)
+Task(subagent_type="pr-review-toolkit:code-reviewer",
+     prompt="Review the local diff (git diff against the base branch) for bugs, security issues, and convention violations. Report findings by severity.")
 ```
 
 ### 3. Check Coverage Gaps

--- a/home/.claude/hooks/post-tool-failure.sh
+++ b/home/.claude/hooks/post-tool-failure.sh
@@ -10,7 +10,14 @@
 set -euo pipefail
 
 # Source user's environment for AGENT_EVENT_BUS_URL
-[[ -f ~/.extra ]] && source ~/.extra
+if [[ -f ~/.extra ]]; then
+    # ~/.extra is user-edited and untracked; a stray unset var or non-zero
+    # line must not abort the hook under set -euo pipefail.
+    set +eu
+    # shellcheck source=/dev/null
+    source ~/.extra
+    set -eu
+fi
 
 # Read input (must consume stdin before any exit)
 INPUT=$(cat)

--- a/home/.claude/hooks/pre-compact.sh
+++ b/home/.claude/hooks/pre-compact.sh
@@ -9,7 +9,14 @@
 set -euo pipefail
 
 # Source user's environment for AGENT_EVENT_BUS_URL
-[[ -f ~/.extra ]] && source ~/.extra
+if [[ -f ~/.extra ]]; then
+    # ~/.extra is user-edited and untracked; a stray unset var or non-zero
+    # line must not abort the hook under set -euo pipefail.
+    set +eu
+    # shellcheck source=/dev/null
+    source ~/.extra
+    set -eu
+fi
 
 # Read and parse session info
 INPUT=$(cat)

--- a/home/.claude/hooks/prompt-events.sh
+++ b/home/.claude/hooks/prompt-events.sh
@@ -10,7 +10,14 @@
 set -euo pipefail
 
 # Source user's environment for AGENT_EVENT_BUS_URL
-[[ -f ~/.extra ]] && source ~/.extra
+if [[ -f ~/.extra ]]; then
+    # ~/.extra is user-edited and untracked; a stray unset var or non-zero
+    # line must not abort the hook under set -euo pipefail.
+    set +eu
+    # shellcheck source=/dev/null
+    source ~/.extra
+    set -eu
+fi
 
 # Read session info (always consume stdin to avoid broken pipe)
 INPUT=$(cat)

--- a/home/.claude/hooks/session-end.sh
+++ b/home/.claude/hooks/session-end.sh
@@ -7,7 +7,14 @@
 set -euo pipefail
 
 # Source user's environment for AGENT_EVENT_BUS_URL
-[[ -f ~/.extra ]] && source ~/.extra
+if [[ -f ~/.extra ]]; then
+    # ~/.extra is user-edited and untracked; a stray unset var or non-zero
+    # line must not abort the hook under set -euo pipefail.
+    set +eu
+    # shellcheck source=/dev/null
+    source ~/.extra
+    set -eu
+fi
 
 # Read and parse session info
 INPUT=$(cat)

--- a/home/.claude/hooks/session-start.sh
+++ b/home/.claude/hooks/session-start.sh
@@ -7,7 +7,14 @@
 set -euo pipefail
 
 # Source user's environment for AGENT_EVENT_BUS_URL
-[[ -f ~/.extra ]] && source ~/.extra
+if [[ -f ~/.extra ]]; then
+    # ~/.extra is user-edited and untracked; a stray unset var or non-zero
+    # line must not abort the hook under set -euo pipefail.
+    set +eu
+    # shellcheck source=/dev/null
+    source ~/.extra
+    set -eu
+fi
 
 # Read and parse session info
 INPUT=$(cat)

--- a/home/.claude/hooks/task-completed.sh
+++ b/home/.claude/hooks/task-completed.sh
@@ -10,7 +10,14 @@
 set -euo pipefail
 
 # Source user's environment for AGENT_EVENT_BUS_URL
-[[ -f ~/.extra ]] && source ~/.extra
+if [[ -f ~/.extra ]]; then
+    # ~/.extra is user-edited and untracked; a stray unset var or non-zero
+    # line must not abort the hook under set -euo pipefail.
+    set +eu
+    # shellcheck source=/dev/null
+    source ~/.extra
+    set -eu
+fi
 
 # Read input (must consume stdin before any exit)
 INPUT=$(cat)

--- a/home/.claude/hooks/task-created.sh
+++ b/home/.claude/hooks/task-created.sh
@@ -10,7 +10,14 @@
 set -euo pipefail
 
 # Source user's environment for AGENT_EVENT_BUS_URL
-[[ -f ~/.extra ]] && source ~/.extra
+if [[ -f ~/.extra ]]; then
+    # ~/.extra is user-edited and untracked; a stray unset var or non-zero
+    # line must not abort the hook under set -euo pipefail.
+    set +eu
+    # shellcheck source=/dev/null
+    source ~/.extra
+    set -eu
+fi
 
 # Read input (must consume stdin before any exit)
 INPUT=$(cat)

--- a/home/.claude/hooks/teammate-idle.sh
+++ b/home/.claude/hooks/teammate-idle.sh
@@ -9,7 +9,14 @@
 set -euo pipefail
 
 # Source user's environment for AGENT_EVENT_BUS_URL
-[[ -f ~/.extra ]] && source ~/.extra
+if [[ -f ~/.extra ]]; then
+    # ~/.extra is user-edited and untracked; a stray unset var or non-zero
+    # line must not abort the hook under set -euo pipefail.
+    set +eu
+    # shellcheck source=/dev/null
+    source ~/.extra
+    set -eu
+fi
 
 # Read input (must consume stdin before any exit)
 INPUT=$(cat)

--- a/home/.claude/statusline-command.sh
+++ b/home/.claude/statusline-command.sh
@@ -18,11 +18,12 @@ if [[ -z "$input" ]]; then
     exit 1
 fi
 
-IFS=$'\t' read -r cwd session_id model_id input_tokens cache_create_tokens cache_read_tokens context_size < <(
+IFS=$'\t' read -r cwd session_id model_id model_name input_tokens cache_create_tokens cache_read_tokens context_size < <(
     echo "$input" | jq -r '[
         .workspace.current_dir,
         (.session_id // ""),
         (.model.id // ""),
+        (.model.display_name // ""),
         (.context_window.current_usage.input_tokens // 0),
         (.context_window.current_usage.cache_creation_input_tokens // 0),
         (.context_window.current_usage.cache_read_input_tokens // 0),
@@ -55,8 +56,13 @@ if [[ -n "$session_id" ]]; then
         # Clean up stale cache files (older than 24 hours)
         find "$cache_dir" -type f -mtime +1 -delete 2>/dev/null
 
+        nosession_sentinel="${cache_file}.miss"
         if [[ -f "$cache_file" ]]; then
             session_name=$(cat "$cache_file")
+        elif find "$nosession_sentinel" -mmin -1 2>/dev/null | grep -q .; then
+            # Recently failed to find this session; skip the retry loop so an
+            # unregistered/bus-down session doesn't pay ~0.6s on every render.
+            session_name=""
         else
             # Query event bus for session matching this client_id
             # Retry briefly: statusline can fire before session-start hook registers
@@ -70,10 +76,12 @@ if [[ -n "$session_id" ]]; then
                 sleep 0.2
             done
 
-            # Cache only successful lookups (empty = session not registered yet)
+            mkdir -p "$cache_dir" && chmod 700 "$cache_dir" 2>/dev/null
             if [[ -n "$session_name" ]]; then
-                mkdir -p "$cache_dir" && chmod 700 "$cache_dir" 2>/dev/null
                 echo "$session_name" > "$cache_file" 2>/dev/null
+            else
+                # Negative-cache the miss (~60s) to avoid re-running the retry loop every render.
+                : > "$nosession_sentinel" 2>/dev/null
             fi
         fi
 
@@ -116,20 +124,59 @@ cache_fresh() {
     (( $(date +%s) - mtime < ttl ))
 }
 
+# Atomic cache write: temp + rename, so a concurrent render never reads a torn file.
+cache_write() {
+    local file="$1" val="$2"
+    printf '%s' "$val" > "${file}.tmp.$$" 2>/dev/null && mv -f "${file}.tmp.$$" "$file" 2>/dev/null
+}
+
+# Bounded GitHub calls: the statusline renders on every prompt, so a hung gh
+# (unauthenticated, offline, slow DNS/TLS) must never block. Wrap calls with a
+# timeout (timeout on Linux, gtimeout from coreutils on macOS; no-op if neither)
+# and short-circuit the whole GitHub section unless gh is installed AND authed.
+if command -v timeout >/dev/null 2>&1; then
+    GH_TIMEOUT=(timeout 3)
+elif command -v gtimeout >/dev/null 2>&1; then
+    GH_TIMEOUT=(gtimeout 3)
+else
+    GH_TIMEOUT=()
+fi
+
+gh_ok=false
+if command -v gh >/dev/null 2>&1; then
+    gh_auth_cache="${gh_cache_dir}/gh_auth_ok"
+    if cache_fresh "$gh_auth_cache" 300; then
+        [[ "$(cat "$gh_auth_cache" 2>/dev/null)" == "yes" ]] && gh_ok=true
+    elif "${GH_TIMEOUT[@]}" gh auth status >/dev/null 2>&1; then
+        gh_ok=true
+        cache_write "$gh_auth_cache" "yes"
+    else
+        cache_write "$gh_auth_cache" "no"
+    fi
+fi
+
 # Get repo URL for hyperlinks (cached per cwd — never changes within a session)
 repo_url=""
 if [[ -n "$cwd" ]] && git -C "$cwd" rev-parse --git-dir > /dev/null 2>&1; then
     repo_cache_key=$(echo "$cwd" | tr '/' '_')
     repo_cache_file="${gh_cache_dir}/repo_${repo_cache_key}"
 
-    if [[ -f "$repo_cache_file" ]]; then
+    if cache_fresh "$repo_cache_file" 3600; then
         repo_url=$(cat "$repo_cache_file")
-    else
-        repo_url=$(cd "$cwd" && gh repo view --json url -q .url 2>/dev/null)
-        if [[ -n "$repo_url" ]]; then
-            echo "$repo_url" > "$repo_cache_file" 2>/dev/null
-        fi
+        [[ "$repo_url" == "none" ]] && repo_url=""
+    elif [[ "$gh_ok" == true ]]; then
+        repo_url=$(cd "$cwd" && "${GH_TIMEOUT[@]}" gh repo view --json url -q .url 2>/dev/null)
+        # Negative-cache empties so a transient failure doesn't re-block every render.
+        cache_write "$repo_cache_file" "${repo_url:-none}"
     fi
+fi
+
+# Repo slug (owner_repo) for cache keys that must not collide across repos —
+# PR #5 exists in nearly every repo, so body_/ci_ keyed on pr_num alone would
+# serve repo A's PR data for repo B.
+repo_slug="${repo_cache_key:-$(echo "${cwd:-}" | tr '/' '_')}"
+if [[ -n "$repo_url" ]]; then
+    repo_slug=$(echo "$repo_url" | sed -E 's#^https?://[^/]+/##; s#/#_#g')
 fi
 
 # Build combined [repo/session] display
@@ -181,28 +228,27 @@ if [[ -n "$cwd" ]] && git -C "$cwd" rev-parse --git-dir > /dev/null 2>&1; then
     pr_num=""
     if [[ -n "$branch" ]]; then
         branch_key=$(echo "$branch" | tr '/' '_')
-        pr_cache_file="${gh_cache_dir}/pr_${branch_key}"
+        pr_cache_file="${gh_cache_dir}/pr_${repo_slug}_${branch_key}"
         if cache_fresh "$pr_cache_file" 60; then
             cached_val=$(cat "$pr_cache_file")
             [[ "$cached_val" != "none" ]] && pr_num="$cached_val"
-        else
-            pr_num=$(cd "$cwd" && gh pr list --head "$branch" --json number -q '.[0].number' 2>/dev/null)
-            echo "${pr_num:-none}" > "$pr_cache_file" 2>/dev/null
+        elif [[ "$gh_ok" == true ]]; then
+            pr_num=$(cd "$cwd" && "${GH_TIMEOUT[@]}" gh pr list --head "$branch" --json number -q '.[0].number' 2>/dev/null)
+            cache_write "$pr_cache_file" "${pr_num:-none}"
         fi
     fi
 
     # Check for linked issues - from PR body (cached with PR) or branch name
     if [[ -n "$pr_num" ]]; then
-        body_cache_file="${gh_cache_dir}/body_${pr_num}"
+        body_cache_file="${gh_cache_dir}/body_${repo_slug}_${pr_num}"
         pr_body=""
         if cache_fresh "$body_cache_file" 60; then
             pr_body=$(cat "$body_cache_file")
-        fi
-        if [[ -z "$pr_body" ]]; then
-            pr_body=$(cd "$cwd" && gh pr view "$pr_num" --json body -q '.body' 2>/dev/null)
-            if [[ -n "$pr_body" ]]; then
-                echo "$pr_body" > "$body_cache_file" 2>/dev/null
-            fi
+            [[ "$pr_body" == "__EMPTY__" ]] && pr_body=""
+        elif [[ "$gh_ok" == true ]]; then
+            pr_body=$(cd "$cwd" && "${GH_TIMEOUT[@]}" gh pr view "$pr_num" --json body -q '.body' 2>/dev/null)
+            # Negative-cache empty bodies (PR may legitimately have none) so we don't refetch every render.
+            cache_write "$body_cache_file" "${pr_body:-__EMPTY__}"
         fi
         if [[ -n "$pr_body" ]]; then
             issue_nums=$(echo "$pr_body" | grep -oiE '(fixes|closes|resolves|addresses) #[0-9]+' | grep -oE '[0-9]+' | sort -u)
@@ -231,15 +277,13 @@ if [[ -n "$cwd" ]] && git -C "$cwd" rev-parse --git-dir > /dev/null 2>&1; then
 
     # CI status indicator (cached for 30s, hidden when dirty — result is stale)
     if [[ -n "$pr_num" ]] && [[ "$git_dirty" == false ]]; then
-        ci_cache_file="${gh_cache_dir}/ci_${pr_num}"
+        ci_cache_file="${gh_cache_dir}/ci_${repo_slug}_${pr_num}"
 
         ci_status=""
         if cache_fresh "$ci_cache_file" 30; then
             ci_status=$(cat "$ci_cache_file")
-        fi
-
-        if [[ -z "$ci_status" ]]; then
-            checks_output=$(cd "$cwd" && gh pr checks "$pr_num" 2>/dev/null || true)
+        elif [[ "$gh_ok" == true ]]; then
+            checks_output=$(cd "$cwd" && "${GH_TIMEOUT[@]}" gh pr checks "$pr_num" 2>/dev/null || true)
             if [[ -n "$checks_output" ]]; then
                 if echo "$checks_output" | awk -F'\t' '{print $2}' | grep -q "fail"; then
                     ci_status="fail"
@@ -248,7 +292,7 @@ if [[ -n "$cwd" ]] && git -C "$cwd" rev-parse --git-dir > /dev/null 2>&1; then
                 else
                     ci_status="pass"
                 fi
-                echo "$ci_status" > "$ci_cache_file" 2>/dev/null
+                cache_write "$ci_cache_file" "$ci_status"
             fi
         fi
 
@@ -269,8 +313,8 @@ fi
 # Final hyperlink reset to ensure no unclosed hyperlinks leak
 LINK_RESET=$'\e]8;;\e\\'
 
-# Model name
-model_display="${model_id:-}"
+# Model name — prefer the friendly display_name (e.g. "Opus 4.8") over the raw id
+model_display="${model_name:-$model_id}"
 
 # Context window usage percentage
 context_display=""

--- a/home/.hermes/config.yaml
+++ b/home/.hermes/config.yaml
@@ -1,0 +1,473 @@
+model:
+  provider: anthropic
+  default: claude-opus-4-8
+providers: {}
+fallback_providers: []
+credential_pool_strategies: {}
+toolsets:
+- hermes-cli
+agent:
+  max_turns: 90
+  gateway_timeout: 1800
+  restart_drain_timeout: 180
+  api_max_retries: 3
+  service_tier: ''
+  tool_use_enforcement: auto
+  task_completion_guidance: true
+  environment_probe: true
+  environment_hint: ''
+  gateway_timeout_warning: 900
+  clarify_timeout: 600
+  gateway_notify_interval: 180
+  gateway_auto_continue_freshness: 3600
+  image_input_mode: auto
+  disabled_toolsets: []
+terminal:
+  backend: local
+  modal_mode: auto
+  cwd: .
+  timeout: 180
+  env_passthrough: []
+  shell_init_files: []
+  auto_source_bashrc: true
+  docker_image: nikolaik/python-nodejs:python3.11-nodejs20
+  docker_forward_env: []
+  docker_env: {}
+  singularity_image: docker://nikolaik/python-nodejs:python3.11-nodejs20
+  modal_image: nikolaik/python-nodejs:python3.11-nodejs20
+  daytona_image: nikolaik/python-nodejs:python3.11-nodejs20
+  container_cpu: 1
+  container_memory: 5120
+  container_disk: 51200
+  container_persistent: true
+  docker_volumes: []
+  docker_mount_cwd_to_workspace: false
+  docker_extra_args: []
+  docker_run_as_host_user: false
+  persistent_shell: true
+web:
+  backend: ''
+  search_backend: ''
+  extract_backend: ''
+browser:
+  inactivity_timeout: 120
+  command_timeout: 30
+  record_sessions: false
+  allow_private_urls: false
+  engine: auto
+  auto_local_for_private_urls: true
+  cdp_url: ''
+  dialog_policy: must_respond
+  dialog_timeout_s: 300
+  camofox:
+    managed_persistence: false
+    user_id: ''
+    session_key: ''
+    adopt_existing_tab: false
+    rewrite_loopback_urls: false
+    loopback_host_alias: host.docker.internal
+checkpoints:
+  enabled: true
+  max_snapshots: 20
+  max_total_size_mb: 500
+  max_file_size_mb: 10
+  auto_prune: true
+  retention_days: 7
+  delete_orphans: true
+  min_interval_hours: 24
+file_read_max_chars: 100000
+tool_output:
+  max_bytes: 50000
+  max_lines: 2000
+  max_line_length: 2000
+tool_loop_guardrails:
+  warnings_enabled: true
+  hard_stop_enabled: true
+  warn_after:
+    exact_failure: 2
+    same_tool_failure: 3
+    idempotent_no_progress: 2
+  hard_stop_after:
+    exact_failure: 5
+    same_tool_failure: 8
+    idempotent_no_progress: 5
+compression:
+  enabled: true
+  threshold: 0.5
+  target_ratio: 0.2
+  protect_last_n: 20
+  hygiene_hard_message_limit: 400
+  protect_first_n: 3
+  abort_on_summary_failure: false
+prompt_caching:
+  cache_ttl: 5m
+openrouter:
+  response_cache: true
+  response_cache_ttl: 300
+  min_coding_score: 0.65
+bedrock:
+  region: ''
+  discovery:
+    enabled: true
+    provider_filter: []
+    refresh_interval: 3600
+  guardrail:
+    guardrail_identifier: ''
+    guardrail_version: ''
+    stream_processing_mode: async
+    trace: disabled
+auxiliary:
+  vision:
+    provider: auto
+    model: ''
+    base_url: ''
+    api_key: ''
+    timeout: 120
+    extra_body: {}
+    download_timeout: 30
+  web_extract:
+    provider: auto
+    model: ''
+    base_url: ''
+    api_key: ''
+    timeout: 360
+    extra_body: {}
+  compression:
+    provider: auto
+    model: ''
+    base_url: ''
+    api_key: ''
+    timeout: 120
+    extra_body: {}
+  skills_hub:
+    provider: auto
+    model: ''
+    base_url: ''
+    api_key: ''
+    timeout: 30
+    extra_body: {}
+  approval:
+    provider: auto
+    model: ''
+    base_url: ''
+    api_key: ''
+    timeout: 30
+    extra_body: {}
+  mcp:
+    provider: auto
+    model: ''
+    base_url: ''
+    api_key: ''
+    timeout: 30
+    extra_body: {}
+  title_generation:
+    provider: auto
+    model: ''
+    base_url: ''
+    api_key: ''
+    timeout: 30
+    extra_body: {}
+  triage_specifier:
+    provider: auto
+    model: ''
+    base_url: ''
+    api_key: ''
+    timeout: 120
+    extra_body: {}
+  kanban_decomposer:
+    provider: auto
+    model: ''
+    base_url: ''
+    api_key: ''
+    timeout: 180
+    extra_body: {}
+  profile_describer:
+    provider: auto
+    model: ''
+    base_url: ''
+    api_key: ''
+    timeout: 60
+    extra_body: {}
+  curator:
+    provider: auto
+    model: ''
+    base_url: ''
+    api_key: ''
+    timeout: 600
+    extra_body: {}
+display:
+  compact: false
+  personality: kawaii
+  resume_display: full
+  resume_exchanges: 10
+  resume_max_user_chars: 300
+  resume_max_assistant_chars: 200
+  resume_max_assistant_lines: 3
+  resume_skip_tool_only: true
+  busy_input_mode: interrupt
+  tui_auto_resume_recent: false
+  tui_agents_nudge: true
+  bell_on_complete: true
+  show_reasoning: false
+  streaming: true
+  timestamps: false
+  final_response_markdown: strip
+  persistent_output: true
+  persistent_output_max_lines: 200
+  inline_diffs: true
+  file_mutation_verifier: true
+  turn_completion_explainer: true
+  show_cost: false
+  skin: default
+  language: en
+  tui_status_indicator: kaomoji
+  user_message_preview:
+    first_lines: 2
+    last_lines: 2
+  interim_assistant_messages: true
+  tool_progress_command: false
+  tool_progress_overrides: {}
+  tool_preview_length: 0
+  ephemeral_system_ttl: 0
+  platforms: {}
+  runtime_footer:
+    enabled: true
+    fields:
+    - model
+    - context_pct
+    - cwd
+  copy_shortcut: auto
+dashboard:
+  theme: default
+  show_token_analytics: false
+  oauth:
+    client_id: ''
+    portal_url: ''
+  public_url: ''
+privacy:
+  redact_pii: false
+tts:
+  provider: edge
+  edge:
+    voice: en-US-AriaNeural
+  elevenlabs:
+    voice_id: pNInz6obpgDQGcFmaJgB
+    model_id: eleven_multilingual_v2
+  openai:
+    model: gpt-4o-mini-tts
+    voice: alloy
+  xai:
+    voice_id: eve
+    language: en
+    sample_rate: 24000
+    bit_rate: 128000
+  mistral:
+    model: voxtral-mini-tts-2603
+    voice_id: c69964a6-ab8b-4f8a-9465-ec0925096ec8
+  neutts:
+    ref_audio: ''
+    ref_text: ''
+    model: neuphonic/neutts-air-q4-gguf
+    device: cpu
+  piper:
+    voice: en_US-lessac-medium
+stt:
+  enabled: true
+  provider: local
+  local:
+    model: base
+    language: ''
+  openai:
+    model: whisper-1
+  mistral:
+    model: voxtral-mini-latest
+voice:
+  record_key: ctrl+b
+  max_recording_seconds: 120
+  auto_tts: false
+  beep_enabled: true
+  silence_threshold: 200
+  silence_duration: 3.0
+human_delay:
+  mode: 'off'
+  min_ms: 800
+  max_ms: 2500
+context:
+  engine: compressor
+memory:
+  memory_enabled: true
+  user_profile_enabled: true
+  memory_char_limit: 2200
+  user_char_limit: 1375
+  provider: ''
+delegation:
+  model: ''
+  provider: ''
+  base_url: ''
+  api_key: ''
+  api_mode: ''
+  inherit_mcp_toolsets: true
+  max_iterations: 50
+  child_timeout_seconds: 600
+  reasoning_effort: ''
+  max_concurrent_children: 3
+  max_spawn_depth: 1
+  orchestrator_enabled: true
+  subagent_auto_approve: true
+prefill_messages_file: ''
+goals:
+  max_turns: 20
+skills:
+  external_dirs: []
+  template_vars: true
+  inline_shell: false
+  inline_shell_timeout: 10
+  guard_agent_created: false
+curator:
+  enabled: true
+  interval_hours: 168
+  min_idle_hours: 2
+  stale_after_days: 30
+  archive_after_days: 90
+  backup:
+    enabled: true
+    keep: 5
+honcho: {}
+timezone: Europe/London
+slack:
+  require_mention: true
+  free_response_channels: ''
+  allowed_channels: ''
+  channel_prompts: {}
+discord:
+  require_mention: true
+  free_response_channels: ''
+  allowed_channels: ''
+  auto_thread: true
+  thread_require_mention: false
+  history_backfill: true
+  history_backfill_limit: 50
+  reactions: true
+  channel_prompts: {}
+  dm_role_auth_guild: ''
+  server_actions: ''
+  allow_any_attachment: false
+  max_attachment_bytes: 33554432
+whatsapp: {}
+telegram:
+  reactions: false
+  channel_prompts: {}
+  allowed_chats: ''
+mattermost:
+  require_mention: true
+  free_response_channels: ''
+  allowed_channels: ''
+  channel_prompts: {}
+matrix:
+  require_mention: true
+  free_response_rooms: ''
+  allowed_rooms: ''
+approvals:
+  mode: manual
+  timeout: 60
+  cron_mode: deny
+  mcp_reload_confirm: true
+  destructive_slash_confirm: true
+command_allowlist: []
+quick_commands: {}
+hooks: {}
+hooks_auto_accept: false
+personalities: {}
+security:
+  allow_private_urls: false
+  redact_secrets: true
+  tirith_enabled: true
+  tirith_path: tirith
+  tirith_timeout: 5
+  tirith_fail_open: true
+  website_blocklist:
+    enabled: false
+    domains: []
+    shared_files: []
+  acked_advisories: []
+  allow_lazy_installs: true
+cron:
+  wrap_response: true
+  max_parallel_jobs: null
+kanban:
+  dispatch_in_gateway: true
+  dispatch_interval_seconds: 60
+  failure_limit: 2
+  worker_log_rotate_bytes: 2097152
+  worker_log_backup_count: 1
+  orchestrator_profile: ''
+  default_assignee: ''
+  max_in_progress_per_profile: null
+  auto_decompose: true
+  auto_decompose_per_tick: 3
+  dispatch_stale_timeout_seconds: 14400
+code_execution:
+  mode: project
+tools:
+  tool_search:
+    enabled: auto
+    threshold_pct: 10
+    search_default_limit: 5
+    max_search_limit: 20
+  auto_approve: true
+logging:
+  level: INFO
+  max_size_mb: 5
+  backup_count: 3
+  memory_monitor:
+    enabled: true
+    interval_seconds: 300
+model_catalog:
+  enabled: true
+  url: https://hermes-agent.nousresearch.com/docs/api/model-catalog.json
+  ttl_hours: 24
+  providers: {}
+network:
+  force_ipv4: false
+gateway:
+  strict: false
+  media_delivery_allow_dirs: []
+  trust_recent_files: true
+  trust_recent_files_seconds: 600
+sessions:
+  auto_prune: false
+  retention_days: 90
+  vacuum_after_prune: true
+  min_interval_hours: 24
+  write_json_snapshots: false
+onboarding:
+  seen:
+    openclaw_residue_cleanup: true
+    tool_progress_prompt: true
+    busy_input_prompt: true
+updates:
+  pre_update_backup: true
+  backup_keep: 5
+lsp:
+  enabled: true
+  wait_mode: document
+  wait_timeout: 5.0
+  install_strategy: auto
+  servers: {}
+x_search:
+  model: grok-4.20-reasoning
+  timeout_seconds: 180
+  retries: 2
+secrets:
+  bitwarden:
+    enabled: false
+    access_token_env: BWS_ACCESS_TOKEN
+    project_id: ''
+    cache_ttl_seconds: 300
+    override_existing: true
+    auto_install: true
+    server_url: ''
+paste_collapse_threshold: 5
+paste_collapse_threshold_fallback: 5
+paste_collapse_char_threshold: 2000
+_config_version: 24

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -349,6 +349,67 @@ test_flag_no_args_prompts() {
 }
 
 # ============================================================================
+# New-machine readiness (behavioral)
+# ============================================================================
+
+# Load the REAL is_gateway_host definition from bootstrap.sh (not a copy),
+# without executing bootstrap's unguarded main.
+_load_is_gateway_host() {
+    eval "$(sed -n '/^is_gateway_host() {/,/^}/p' "$BOOTSTRAP")"
+}
+
+test_gateway_host_matches_plain() {
+    _load_is_gateway_host
+    HOSTNAME="mac-mini" is_gateway_host
+}
+
+test_gateway_host_matches_bonjour_suffix() {
+    # macOS Bonjour appends -N on mDNS collision; the gate must still match.
+    _load_is_gateway_host
+    HOSTNAME="mac-mini-2" is_gateway_host
+}
+
+test_gateway_host_matches_fqdn() {
+    _load_is_gateway_host
+    HOSTNAME="mac-mini-2.tailac7b3c.ts.net" is_gateway_host
+}
+
+test_gateway_host_rejects_other() {
+    _load_is_gateway_host
+    ! HOSTNAME="steamdeck" is_gateway_host && ! HOSTNAME="mac-mini-laptop" is_gateway_host
+}
+
+# obsidian-mcp-start must NOT exec the server when the Obsidian REST API is down
+# (the KeepAlive crash-loop). It should back off and exit non-zero instead.
+test_obsidian_preflight_backs_off_when_upstream_down() {
+    local wrapper="$SCRIPT_DIR/../home/.bin/obsidian-mcp-start"
+    [[ -f "$wrapper" ]] || return 1
+    local stub home; stub=$(mktemp -d); home=$(mktemp -d)
+    printf '#!/bin/bash\nexit 1\n' > "$stub/curl"                      # upstream down
+    printf '#!/bin/bash\nexit 0\n' > "$stub/sleep"                     # don't actually wait 15s
+    printf '#!/bin/bash\ntouch "%s/server_ran"\n' "$home" > "$stub/obsidian-mcp-server"
+    chmod +x "$stub"/*
+    local rc=0
+    PATH="$stub:$PATH" HOME="$home" OBSIDIAN_API_KEY="test" bash "$wrapper" >/dev/null 2>&1 || rc=$?
+    local ran=1; [[ -e "$home/server_ran" ]] && ran=0
+    rm -rf "$stub" "$home"
+    [[ "$rc" -ne 0 && "$ran" -ne 0 ]]   # non-zero exit AND server did not run
+}
+
+test_obsidian_preflight_starts_when_upstream_up() {
+    local wrapper="$SCRIPT_DIR/../home/.bin/obsidian-mcp-start"
+    [[ -f "$wrapper" ]] || return 1
+    local stub home; stub=$(mktemp -d); home=$(mktemp -d)
+    printf '#!/bin/bash\nexit 0\n' > "$stub/curl"                      # upstream up
+    printf '#!/bin/bash\ntouch "%s/server_ran"\nexit 0\n' "$home" > "$stub/obsidian-mcp-server"
+    chmod +x "$stub"/*
+    PATH="$stub:$PATH" HOME="$home" OBSIDIAN_API_KEY="test" bash "$wrapper" >/dev/null 2>&1 || true
+    local ran=1; [[ -e "$home/server_ran" ]] && ran=0
+    rm -rf "$stub" "$home"
+    [[ "$ran" -eq 0 ]]   # server was exec'd
+}
+
+# ============================================================================
 # Run all tests
 # ============================================================================
 
@@ -395,6 +456,15 @@ main() {
     run_test "--pull runs pull+install+update+sync" "test_flag_pull_only"
     run_test "short flags (-f -p) match long flags" "test_flag_short_forms"
     run_test "no flags: sync dotfiles with prompt" "test_flag_no_args_prompts"
+    echo ""
+
+    echo "=== new-machine readiness ==="
+    run_test "host-gating matches mac-mini" "test_gateway_host_matches_plain"
+    run_test "host-gating tolerates Bonjour -N suffix" "test_gateway_host_matches_bonjour_suffix"
+    run_test "host-gating matches FQDN with suffix" "test_gateway_host_matches_fqdn"
+    run_test "host-gating rejects non-gateway hosts" "test_gateway_host_rejects_other"
+    run_test "obsidian preflight backs off when upstream down" "test_obsidian_preflight_backs_off_when_upstream_down"
+    run_test "obsidian preflight starts server when upstream up" "test_obsidian_preflight_starts_when_upstream_up"
     echo ""
 
     # Summary


### PR DESCRIPTION
## Summary

New-machine readiness audit (7 parallel audit agents + cross-session findings from a sibling `projects` session and the event bus). One combined PR with per-surface commits. **No secrets committed.**

## Surfaces

**bootstrap reliability** (`50749a9`)
- `launchctl bootstrap` (×2) lacked `|| true` — under `set -euo pipefail`, re-bootstrapping an already-loaded agent aborts the whole run.
- Host-gating exact-match `== "mac-mini"` → `is_gateway_host` helper matching `^mac-mini(-[0-9]+)?$`, so the macOS Bonjour `-N` LocalHostName suffix (`mac-mini-2`) doesn't silently demote the gateway.

**workflow/commands** (`c42b57b`)
- `/pr-review` step 2 called `Skill(pr-review-toolkit:code-reviewer)`, but that's an **agent** → no-ops every run. Now `Task(...)`.
- Agents referenced as `/slash-commands` clarified as Task-invoked.
- `--body-file` convention added to 5 `gh` body/title sites (bare `--body "..."` shell-evaluates `[[`/`==`/parens — confirmed past failure).

**statusline** (`434d8de`) — Critical fresh-machine blocker
- Every render made unbounded `gh` calls with no negative cache → unauthenticated/offline `gh` blocked the prompt for seconds, re-attempting every render. Now: timeout-wrapped, `gh auth status` short-circuit, negative caching.
- Repo-scoped `pr/body/ci` cache keys (PR #5 exists in every repo → was serving repo A's CI for repo B).
- Atomic cache writes; event-bus miss negative-cached; model `display_name` instead of raw id.

**hooks** (`a46edd8`)
- All 8 hooks sourced `~/.extra` under `set -euo pipefail` — a stray unset var / non-zero line in that user-edited file aborts the hook (silently skipping enforcement/registration). Now wrapped in `set +eu`/`set -eu`.

**tests** (`21aaa59`)
- Behavioral tests (real functions, not greps): `is_gateway_host` (mac-mini / `-2` suffix / FQDN / rejects others), and `obsidian-mcp-start` preflight (backs off + doesn't exec server when REST API down — regresses the #313 crash-loop).
- `make test` now `bash -n`s every `home/.bin/*`.

**docs** (`4d049a1`)
- Host-gating section matches the new helper; README documents the `~/.extra` secrets a new machine needs (`OPENCLAW_GATEWAY_TOKEN`, `OBSIDIAN_API_KEY`); `agent-memory-store` flagged as documented-but-not-bootstrap-wired; repo-managed LaunchAgents enumerated.

**hermes** (`ebd12a5`)
- Track `~/.hermes/config.yaml` (auto-symlinked). hermes supports `${VAR}` interpolation, but this config has **no credentials** (API keys empty/env-referenced, bitwarden block disabled). Verified before commit.

**aliases** (`9b209a8`) — `claude-yolo` → `ccyolo`.

## Verified, not changed
- `home/.claude/contrib/agent-event-bus/{data.db,*.log,*.err}` are **already gitignored** (`.gitignore:15`) — the "tracked runtime state" finding was a false positive; a fresh clone never gets them.

## Deferred to focused PRs
- `actions/checkout@v4 → v5` (Node20 EOL) — separate, per the `claude-code-action` validates-against-main gotcha.
- `enforce-insight-publish.sh` transcript-stabilization race — needs a writer-lag regression test; it's the enforcement hook, so it gets its own tested PR.

## Test plan
- [x] `make check` — 88 hook + 35 bootstrap tests pass; shellcheck clean
- [x] statusline smoke-tested incl. no-`gh` path (no hang)
- [x] sysload/obsidian/host-gating behaviors verified
- [ ] post-merge: `./bootstrap.sh -f` to apply symlinks (incl. `~/.hermes`)

## For your call
- The bitwarden block in the hermes config has a `project_id`/`server_url` (identifiers, not credentials, block disabled). Committed as-is — say the word if you'd rather externalize them via `${VAR}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
