### PR TITLE
fix(bootstrap): gate npm registry config on corp gcloud account

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -15,6 +15,11 @@ cd "$(dirname "${BASH_SOURCE}")";
 GATEWAY_HOST="mac-mini.tailac7b3c.ts.net"
 INSTALL_AI=""
 
+# Domain of the gcloud account that can reach the internal npm Artifact Registry.
+# configure_npm_registry no-ops unless the active account ends in this domain, so
+# personal-account machines don't print a spurious PERMISSION_DENIED warning.
+CORP_NPM_DOMAIN="@anthropic.com"
+
 # Set up Homebrew environment variables
 if [[ "$(uname)" == "Darwin" ]]; then
 	if [[ -f "/opt/homebrew/bin/brew" ]]; then
@@ -1204,6 +1209,14 @@ configure_npm_registry() {
 	local active_account
 	active_account=$(gcloud config get-value account 2>/dev/null) || return 0
 	if [[ -z "$active_account" ]]; then
+		return 0
+	fi
+
+	# The Artifact Registry repo is corp-internal. A personal account (e.g.
+	# gmail.com) gets PERMISSION_DENIED, so skip silently unless the active
+	# account is a corp account — otherwise every `-p` run prints a useless
+	# warning on personal machines.
+	if [[ "$active_account" != *"$CORP_NPM_DOMAIN" ]]; then
 		return 0
 	fi
 

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -409,6 +409,48 @@ test_obsidian_preflight_starts_when_upstream_up() {
     [[ "$ran" -eq 0 ]]   # server was exec'd
 }
 
+# configure_npm_registry must only touch the internal Artifact Registry when the
+# active gcloud account is a corp account. A personal account (gmail.com) should
+# no-op silently instead of printing a PERMISSION_DENIED warning every -p run.
+#
+# Loads the REAL constant + function from bootstrap.sh, stubs gcloud/npm on PATH,
+# and asserts via a marker file whether print-settings was reached.
+_run_configure_npm_registry() {
+    local account="$1" home="$2" stub="$3"
+    eval "$(grep '^CORP_NPM_DOMAIN=' "$BOOTSTRAP")"
+    eval "$(sed -n '/^configure_npm_registry() {/,/^}/p' "$BOOTSTRAP")"
+    # gcloud stub: report the account; mark + emit settings on print-settings.
+    {
+        printf '#!/bin/bash\n'
+        printf 'if [[ "$1" == config ]]; then echo "%s"; exit 0; fi\n' "$account"
+        printf 'if [[ "$1" == artifacts ]]; then touch "%s/print_settings_called"; echo "//registry=x"; exit 0; fi\n' "$home"
+        printf 'exit 0\n'
+    } > "$stub/gcloud"
+    printf '#!/bin/bash\nexit 0\n' > "$stub/npm"
+    chmod +x "$stub/gcloud" "$stub/npm"
+    PATH="$stub:$PATH" HOME="$home" configure_npm_registry >/dev/null 2>&1
+}
+
+test_npm_registry_skips_personal_account() {
+    local home stub; home=$(mktemp -d); stub=$(mktemp -d)
+    _run_configure_npm_registry "evansenter@gmail.com" "$home" "$stub"
+    local called=1 wrote=1
+    [[ -e "$home/print_settings_called" ]] && called=0
+    [[ -e "$home/.npmrc" ]] && wrote=0
+    rm -rf "$home" "$stub"
+    [[ "$called" -ne 0 && "$wrote" -ne 0 ]]   # never reached print-settings, never wrote .npmrc
+}
+
+test_npm_registry_runs_for_corp_account() {
+    local home stub; home=$(mktemp -d); stub=$(mktemp -d)
+    _run_configure_npm_registry "someone@anthropic.com" "$home" "$stub"
+    local called=1 wrote=1
+    [[ -e "$home/print_settings_called" ]] && called=0
+    [[ -e "$home/.npmrc" ]] && wrote=0
+    rm -rf "$home" "$stub"
+    [[ "$called" -eq 0 && "$wrote" -eq 0 ]]   # reached print-settings AND wrote .npmrc
+}
+
 # ============================================================================
 # Run all tests
 # ============================================================================
@@ -465,6 +507,8 @@ main() {
     run_test "host-gating rejects non-gateway hosts" "test_gateway_host_rejects_other"
     run_test "obsidian preflight backs off when upstream down" "test_obsidian_preflight_backs_off_when_upstream_down"
     run_test "obsidian preflight starts server when upstream up" "test_obsidian_preflight_starts_when_upstream_up"
+    run_test "npm registry skips personal gcloud account" "test_npm_registry_skips_personal_account"
+    run_test "npm registry runs for corp gcloud account" "test_npm_registry_runs_for_corp_account"
     echo ""
 
     # Summary


### PR DESCRIPTION
## Problem

On `./bootstrap.sh -p`, `configure_npm_registry` ran `gcloud artifacts print-settings npm` against the internal `ah-3p-staging-npm` Artifact Registry repo for **any** active gcloud account. On a personal account (e.g. `gmail.com`) that call returns `PERMISSION_DENIED`, so the function fell into its `else` branch and printed:

```
  Warning: Failed to configure NPM credentials automatically
```

every single `-p` run. It's harmless — public npm installs already pass `--registry https://registry.npmjs.org/` explicitly and no `~/.npmrc` entry is needed — but it's noise on personal machines.

## Fix

Add a `CORP_NPM_DOMAIN="@anthropic.com"` constant and skip `configure_npm_registry` **silently** unless the active gcloud account ends in that domain. Corp machines behave exactly as before; personal machines no-op cleanly.

## Tests

Two new behavioral tests in `tests/test-bootstrap.sh` that load the **real** constant + function from `bootstrap.sh` (via `sed`/`grep`, same pattern as the existing `is_gateway_host` tests), stub `gcloud`/`npm` on `PATH`, and assert via a marker file:

- `npm registry skips personal gcloud account` — `gmail.com` account never reaches `print-settings`, never writes `~/.npmrc`
- `npm registry runs for corp gcloud account` — `@anthropic.com` account does both

Mutation-verified: removing the gate flips the personal-account test to red. `make check` green (lint, 37 bootstrap tests, hooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)