### PR TITLE
Workflow review: adopt loop primitives + recent CC features (Notification hook, /schedule-audits)

### DIFF
--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -54,6 +54,18 @@ Use `/work <issue-number>` for guided development. `/work --attach` to join an e
 - **On feedback**: Present via AskUserQuestion. Form your own opinion—you have context reviewers lack
 - **After fixes**: Push → auto-cycle repeats until clean
 
+## Loops & Automation
+
+A loop is repeating cycles of work until a stop condition is met. Pick the lightest primitive that fits, and write the verification check *before* handing work to a loop — if "done" can't be checked deterministically, keep it turn-based.
+
+- **Turn-based** (default): user steers each iteration. For exploratory or judgment-heavy work.
+- **Goal-based** (`/goal`): work with a checkable done-condition. Use deterministic criteria (tests pass, CI green, zero Critical findings) — the evaluator blocks premature "good enough" stops. Set a turn cap.
+- **Time-based** (`/loop <interval>`): polling external systems only. Prefer event-driven signals (event bus, background task notifications, `--watch` flags) over time-driven polling; when you must poll, use the longest interval that works.
+- **Scheduled** (`/schedule` Routines): recurring maintenance on a calendar — e.g., weekly `audit-*` agent sweeps, dependency freshness checks.
+- **Dynamic workflows** (ask for a workflow): fan out many agents for wide sweeps — audits, migrations, multi-lens reviews. Monitor with `/workflows`.
+
+After a loop runs, note where it stalled or over-reached, then tighten the stop condition or interval. Never busy-wait with foreground `sleep` — background the watcher or use `/loop`.
+
 ## Event Bus
 
 Cross-session coordination. Sessions auto-register on startup.

--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -61,7 +61,7 @@ A loop is repeating cycles of work until a stop condition is met. Pick the light
 - **Turn-based** (default): user steers each iteration. For exploratory or judgment-heavy work.
 - **Goal-based** (`/goal`): work with a checkable done-condition. Use deterministic criteria (tests pass, CI green, zero Critical findings) — the evaluator blocks premature "good enough" stops. Set a turn cap.
 - **Time-based** (`/loop <interval>`): polling external systems only. Prefer event-driven signals (event bus, background task notifications, `--watch` flags) over time-driven polling; when you must poll, use the longest interval that works.
-- **Scheduled** (`/schedule` Routines): recurring maintenance on a calendar — e.g., weekly `audit-*` agent sweeps, dependency freshness checks.
+- **Scheduled** (`/schedule` Routines): recurring maintenance on a calendar — e.g., weekly `audit-*` agent sweeps (`/schedule-audits`), dependency freshness checks.
 - **Dynamic workflows** (ask for a workflow): fan out many agents for wide sweeps — audits, migrations, multi-lens reviews. Monitor with `/workflows`.
 
 After a loop runs, note where it stalled or over-reached, then tighten the stop condition or interval. Never busy-wait with foreground `sleep` — background the watcher or use `/loop`.

--- a/home/.claude/agents/improve-workflow.md
+++ b/home/.claude/agents/improve-workflow.md
@@ -82,6 +82,16 @@ For each error pattern with 3+ occurrences across sessions:
 
 **Skip if:** Error rate is ≤ 5% (Phase 2 already gates this).
 
+### Loop Opportunities
+
+While reviewing the data above (no extra queries), flag work the user is the bottleneck for that has a deterministic done-check — it's a candidate for a loop primitive:
+
+- Same fix-verify cycle repeated across turns with a checkable stop condition → suggest `/goal <condition>`
+- Session polled an external system on a timer → suggest `/loop <interval>` (or an event source if one exists)
+- Same manual maintenance task appearing across sessions (audits, dependency bumps, cleanups) → suggest a `/schedule` Routine
+
+Only report as a finding if you can name the exact stop condition or schedule — "could be automated" without one is not actionable.
+
 ### Cross-Session Gotchas
 
 Only if insights show `has_bus_events: true`:

--- a/home/.claude/agents/rfc-respond.md
+++ b/home/.claude/agents/rfc-respond.md
@@ -9,7 +9,7 @@ You are an RFC analyst. Respond to existing RFC issues with structured analysis,
 ## Input
 
 The prompt will contain:
-- **issue**: Issue number, URL, or "infer" (check PR body, active `[work:N]` todo, recent conversation)
+- **issue**: Issue number, URL, or "infer" (check PR body, active `[work:N]` task, recent conversation)
 - **flags**: `--post` (auto-post without confirmation)
 - **context**: Any relevant learnings or context from the conversation
 

--- a/home/.claude/commands/pr-review.md
+++ b/home/.claude/commands/pr-review.md
@@ -38,7 +38,7 @@ Use the built-in `code-review` skill — it fans out multiple reviewers and adve
 Skill(skill="code-review", args="medium")
 ```
 
-Use `args="high"` for large or risky diffs (security-sensitive files, >10 files changed).
+Scale effort to the diff: `args="low"` for small or docs-only changes, `args="high"` for large or risky diffs (security-sensitive files, >10 files changed).
 
 **Fallback** (if the built-in skill is unavailable), use the plugin agent via the Task tool:
 

--- a/home/.claude/commands/pr-review.md
+++ b/home/.claude/commands/pr-review.md
@@ -32,7 +32,15 @@ Output 2-3 sentence summary of what changed and why.
 
 ### 2. Run Analysis
 
-`code-reviewer` is an agent, not a skill — invoke it with the Task tool:
+Use the built-in `code-review` skill — it fans out multiple reviewers and adversarially verifies findings before reporting:
+
+```
+Skill(skill="code-review", args="medium")
+```
+
+Use `args="high"` for large or risky diffs (security-sensitive files, >10 files changed).
+
+**Fallback** (if the built-in skill is unavailable), use the plugin agent via the Task tool:
 
 ```
 Task(subagent_type="pr-review-toolkit:code-reviewer",

--- a/home/.claude/commands/schedule-audits.md
+++ b/home/.claude/commands/schedule-audits.md
@@ -32,11 +32,13 @@ Set up a weekly scheduled loop (Routine) that runs the `audit-*` agents against 
 
      ```
      Run the scheduled weekly audit for <repo>. Spawn the <chosen audit-*>
-     agents in parallel via the Agent tool. For each Critical/Important
-     finding: check for an existing GitHub issue first, then file one with
+     subagents in parallel (subagent_type: audit-docs, audit-issues, ...)
+     and collect their reports. This is an unattended run: agents only
+     observe — do not apply their proposed edits and do not push code.
+     You (the lead) then act on the reports: for each Critical/Important
+     finding, check for an existing GitHub issue first, then file one with
      appropriate labels. Publish an `improvement_suggested` event to the
      event bus (channel repo:<repo>) summarizing findings and issue links.
-     Do NOT push code changes — audits only observe and file issues.
      ```
 
 4. **Confirm**: show the Routine name, schedule, agents included, and how to remove it (`/schedule-audits off`).
@@ -52,5 +54,5 @@ Run CronList, find `weekly-audit-<repo>` for the current repo, confirm with the 
 ## Notes
 
 - Findings flow through issues + event bus, so the next interactive session picks them up via `<recent-events>` — the Routine never needs to interrupt you.
-- Keep the cadence weekly. Audits are loops with a fuzzy stop condition (the agents bound their own scope); the schedule is the token-spend control, per the loops guidance.
-- If CronCreate is unavailable (older CC, API-key auth), fall back to telling the user to run `/schedule` interactively with the same prompt.
+- Keep the cadence weekly — the schedule is the token-spend control.
+- If the Cron* tools are unavailable (older CC, API-key auth), fall back to telling the user to run `/schedule` interactively with the same prompt.

--- a/home/.claude/commands/schedule-audits.md
+++ b/home/.claude/commands/schedule-audits.md
@@ -1,0 +1,56 @@
+---
+argument-hint: [status | off]
+description: Create (or manage) a weekly Routine that runs the audit-* agents
+---
+
+# Schedule Audits
+
+Set up a weekly scheduled loop (Routine) that runs the `audit-*` agents against the current repo. Implements the "Scheduled" primitive from the Loops & Automation guidance in global CLAUDE.md: recurring maintenance with a fixed cadence, no user in the loop.
+
+## Usage
+
+```
+/schedule-audits           # Create the weekly Routine for this repo
+/schedule-audits status    # Show existing audit Routines
+/schedule-audits off       # Remove this repo's audit Routine
+```
+
+## Instructions
+
+### Mode: create (no args)
+
+1. **Check for an existing Routine** with CronList. If one named `weekly-audit-<repo>` already exists for this repo, show it and stop — don't create a duplicate.
+
+2. **Pick the audit set.** Default: `audit-docs` and `audit-issues` weekly (cheap, high drift-rate). Ask via AskUserQuestion whether to also include the heavier agents:
+   - **Docs + issues (Recommended)** — audit-docs, audit-issues
+   - **Full sweep** — adds audit-codebase, audit-tests, audit-workflows
+
+3. **Create the Routine** with CronCreate:
+   - Name: `weekly-audit-<repo>`
+   - Schedule: `0 9 * * 1` (Monday 09:00 local)
+   - Prompt (self-contained — the fired session starts fresh):
+
+     ```
+     Run the scheduled weekly audit for <repo>. Spawn the <chosen audit-*>
+     agents in parallel via the Agent tool. For each Critical/Important
+     finding: check for an existing GitHub issue first, then file one with
+     appropriate labels. Publish an `improvement_suggested` event to the
+     event bus (channel repo:<repo>) summarizing findings and issue links.
+     Do NOT push code changes — audits only observe and file issues.
+     ```
+
+4. **Confirm**: show the Routine name, schedule, agents included, and how to remove it (`/schedule-audits off`).
+
+### Mode: `status`
+
+Run CronList and show any `weekly-audit-*` Routines: name, cron expression, next run. If none: "No audit Routines scheduled. Run `/schedule-audits` to create one."
+
+### Mode: `off`
+
+Run CronList, find `weekly-audit-<repo>` for the current repo, confirm with the user, then remove it with CronDelete. If not found, say so.
+
+## Notes
+
+- Findings flow through issues + event bus, so the next interactive session picks them up via `<recent-events>` — the Routine never needs to interrupt you.
+- Keep the cadence weekly. Audits are loops with a fuzzy stop condition (the agents bound their own scope); the schedule is the token-spend control, per the loops guidance.
+- If CronCreate is unavailable (older CC, API-key auth), fall back to telling the user to run `/schedule` interactively with the same prompt.

--- a/home/.claude/commands/watch-ci.md
+++ b/home/.claude/commands/watch-ci.md
@@ -41,7 +41,7 @@ If PR_NUMBER is omitted, uses the current branch's PR.
 
 5. When you receive a task notification about the background command completing, read the output to check results.
 
-   **Never poll with foreground `sleep`** — the background watch notifies on completion. If the background watch dies (network drop, token expiry) or the environment can't hold a long-lived watch, fall back to a time-based loop with a long interval: `/loop 5m check gh pr checks <PR_NUMBER>; stop the loop when checks reach a terminal state`.
+   If the background watch dies (network drop, token expiry) or the environment can't hold a long-lived watch, fall back to a time-based loop with a long interval: `/loop 5m check gh pr checks <PR_NUMBER>; stop the loop when checks reach a terminal state`. (No foreground `sleep` — see Loops & Automation.)
 
 6. When CI completes:
    - Notify and broadcast:

--- a/home/.claude/commands/watch-ci.md
+++ b/home/.claude/commands/watch-ci.md
@@ -41,6 +41,8 @@ If PR_NUMBER is omitted, uses the current branch's PR.
 
 5. When you receive a task notification about the background command completing, read the output to check results.
 
+   **Never poll with foreground `sleep`** — the background watch notifies on completion. If the background watch dies (network drop, token expiry) or the environment can't hold a long-lived watch, fall back to a time-based loop with a long interval: `/loop 5m check gh pr checks <PR_NUMBER>; stop the loop when checks reach a terminal state`.
+
 6. When CI completes:
    - Notify and broadcast:
      ```

--- a/home/.claude/commands/work.md
+++ b/home/.claude/commands/work.md
@@ -250,7 +250,7 @@ WIP state is **automatically checkpointed** by the `pre-compact.sh` hook before 
 
 ## Checkpoint Handling
 
-**Goal-based loops:** The review→fix and CI→fix cycles below are loops with deterministic stop conditions — good `/goal` candidates. For a fix cycle expected to take more than one round, offer to set a goal (e.g., `/goal CI green on PR #N and /pr-review local reports zero Critical/Important findings`) so the evaluator keeps the loop going instead of stopping at "good enough". Keep judgment-heavy checkpoints (scope, merge confirmation, feedback triage) turn-based.
+**Goal-based loops:** For a review→fix or CI→fix cycle expected to take more than one round, offer to set `/goal` with the deterministic stop condition (e.g., `CI green on PR #N and /pr-review local clean`) — see Loops & Automation. Judgment-heavy checkpoints (scope, merge confirmation, feedback triage) stay turn-based.
 
 **Run /pr-review local**: Run, fix issues if found, loop until clean.
 

--- a/home/.claude/commands/work.md
+++ b/home/.claude/commands/work.md
@@ -18,7 +18,7 @@ Guided development (optional) runs exploration agents, asks clarifying questions
 
 ## Identifiers
 
-Todos use `[work:ID]` prefix:
+Tasks (created via TaskCreate) use `[work:ID]` subject prefix:
 
 | Input | Identifier | Example |
 |-------|------------|---------|
@@ -51,7 +51,7 @@ Join existing PR on current branch, restoring WIP context if available.
 Note: Code checks (lint, test, etc.) and claude-review are separate CI jobs.
 claude-review posts a native GitHub review (approve/request-changes) — check review status with `gh pr view --json reviews`.
 
-6. Create remaining todos only. Display resume plan showing what's done and what remains.
+6. Create remaining tasks only. Display resume plan showing what's done and what remains.
 
 ---
 
@@ -59,9 +59,9 @@ claude-review posts a native GitHub review (approve/request-changes) — check r
 
 ### 1. Check for Active Session
 
-If incomplete `[work:*]` todos exist, block new work.
+If incomplete `[work:*]` tasks exist (check TaskList), block new work.
 
-**Note:** Other todos without `[work:*]` prefix don't block (including subagent todos).
+**Note:** Other tasks without `[work:*]` prefix don't block (including subagent tasks).
 
 ### 2. Parse Input
 
@@ -112,7 +112,7 @@ These are preliminary - if user opts into guided development, they'll be refined
 Ask via AskUserQuestion:
 - **Start work** - Proceed to guided development question
 - **Modify scope** - Adjust tasks before starting
-- **Cancel** - Abort without creating todos
+- **Cancel** - Abort without creating tasks
 
 ### 6b. Create Feature Branch
 
@@ -200,7 +200,9 @@ Based on the architecture plan, derive final implementation tasks. These replace
 
 ---
 
-### 8. Create Todos
+### 8. Create Tasks
+
+Create via TaskCreate, one per item:
 
 ```
 [work:${ID}] <task 1>
@@ -242,15 +244,17 @@ WIP state is **automatically checkpointed** by the `pre-compact.sh` hook before 
 
 **Auto-captured:** `[work:ID] | branch | pr: #N | files | time`
 
-**On session resume:** Check `<wip-checkpoint-restored>` tags in session start. Combined with the persisted todo list, this provides enough context to continue work.
+**On session resume:** Check `<wip-checkpoint-restored>` tags in session start. Combined with the persisted task list, this provides enough context to continue work.
 
 ---
 
 ## Checkpoint Handling
 
+**Goal-based loops:** The review→fix and CI→fix cycles below are loops with deterministic stop conditions — good `/goal` candidates. For a fix cycle expected to take more than one round, offer to set a goal (e.g., `/goal CI green on PR #N and /pr-review local reports zero Critical/Important findings`) so the evaluator keeps the loop going instead of stopping at "good enough". Keep judgment-heavy checkpoints (scope, merge confirmation, feedback triage) turn-based.
+
 **Run /pr-review local**: Run, fix issues if found, loop until clean.
 
-**Create PR**: Run `/pr-create`. If adhoc, update remaining todos to `[work:pr-N]`.
+**Create PR**: Run `/pr-create`. If adhoc, update remaining tasks to `[work:pr-N]`.
 
 **Monitor CI**: Run `/watch-ci <PR#>` in background.
 

--- a/home/.claude/hooks/README.md
+++ b/home/.claude/hooks/README.md
@@ -228,7 +228,7 @@ Counting is lenient: one `publish_event` covers all insights in the turn (matche
 **Actions:**
 1. Exit silently if not inside zellij, jq is missing, or stdin isn't valid JSON
 2. Parse `message` and optional `notification_type` from stdin JSON, truncating the message to 60 chars inside jq (codepoint-safe — bash slicing counts bytes under a C locale and can split multibyte chars)
-3. Map type to icon: `agent_completed` → ✅, `permission*` → 🔐, everything else (incl. `agent_needs_input`) → 🔔
+3. Map to icon: `agent_completed` → ✅, permission prompts (`permission*` type, or "permission" in the message text since permission notifications arrive untyped) → 🔐, everything else (incl. `agent_needs_input`) → 🔔
 4. Send `zjstatus::notify::<icon> <message>` via zellij pipe
 
 The notify slot is shared with `zj-status.sh` (working/waiting); notifications intentionally overwrite the working indicator. A mid-turn notification stays visible until the turn ends (`Stop` clears the slot; the next `UserPromptSubmit` rewrites it).

--- a/home/.claude/hooks/README.md
+++ b/home/.claude/hooks/README.md
@@ -35,6 +35,10 @@ Session Start
 │      │   - post-tool-failure.sh     │
 │      │   (detects recurring errors) │
 │      │                              │
+│      ├── Notification hook          │
+│      │   - notification.sh          │
+│      │   (surfaces in zjstatus bar) │
+│      │                              │
 │      ├── Stop hooks (run in order): │
 │      │   1. zj-status.sh waiting    │
 │      │   2. enforce-insight-publish │
@@ -216,6 +220,27 @@ Counting is lenient: one `publish_event` covers all insights in the turn (matche
 
 ---
 
+### notification.sh
+**Trigger:** `Notification`
+
+**Purpose:** Surface Claude Code notifications in the zjstatus bar — permission requests, idle "waiting for input" prompts, and background agent events (`agent_needs_input` / `agent_completed`, fired by background agents since CC v2.1.198).
+
+**Actions:**
+1. Exit silently if not inside zellij or jq is missing
+2. Parse `message` and optional `notification_type` from stdin JSON
+3. Map type to icon: `agent_completed` → ✅, `agent_needs_input` → 🔔, `permission*` → 🔐, default → 🔔
+4. Truncate message to 60 chars and send `zjstatus::notify::<icon> <message>` via zellij pipe
+
+The notify slot is shared with `zj-status.sh` (working/waiting); notifications intentionally overwrite the working indicator, and the next `UserPromptSubmit`/`Stop` restores it.
+
+**Input JSON fields:** `session_id`, `cwd`, `message`, `notification_type` (background agent events only)
+
+**Output:** None (zellij pipe side effect only)
+
+**Exit code:** Always 0 (graceful degradation without zellij/jq).
+
+---
+
 ### post-tool-failure.sh
 **Trigger:** `PostToolUseFailure`
 
@@ -301,7 +326,8 @@ In `settings.json`:
     "TeammateIdle": [{ "hooks": [{ "type": "command", "command": "~/.claude/hooks/teammate-idle.sh" }] }],
     "TaskCreated": [{ "hooks": [{ "type": "command", "command": "~/.claude/hooks/task-created.sh" }] }],
     "TaskCompleted": [{ "hooks": [{ "type": "command", "command": "~/.claude/hooks/task-completed.sh" }] }],
-    "PostToolUseFailure": [{ "hooks": [{ "type": "command", "command": "~/.claude/hooks/post-tool-failure.sh" }] }]
+    "PostToolUseFailure": [{ "hooks": [{ "type": "command", "command": "~/.claude/hooks/post-tool-failure.sh" }] }],
+    "Notification": [{ "hooks": [{ "type": "command", "command": "~/.claude/hooks/notification.sh" }] }]
   }
 }
 ```

--- a/home/.claude/hooks/README.md
+++ b/home/.claude/hooks/README.md
@@ -158,7 +158,7 @@ Session End / Agent Teams
 ---
 
 ### task-created.sh
-**Trigger:** `TaskCreated` (Agent Teams)
+**Trigger:** `TaskCreated` — fires whenever a task is created via the `TaskCreate` tool (solo sessions and Agent Teams alike; `teammate_name`/`team_name` are empty outside teams)
 
 **Purpose:** Broadcast task creation for cross-agent visibility.
 
@@ -175,7 +175,7 @@ Session End / Agent Teams
 ---
 
 ### task-completed.sh
-**Trigger:** `TaskCompleted` (Agent Teams)
+**Trigger:** `TaskCompleted` — fires whenever a task is marked complete (solo sessions and Agent Teams alike; `teammate_name`/`team_name` are empty outside teams)
 
 **Purpose:** Broadcast task completion for coordination.
 

--- a/home/.claude/hooks/README.md
+++ b/home/.claude/hooks/README.md
@@ -226,18 +226,18 @@ Counting is lenient: one `publish_event` covers all insights in the turn (matche
 **Purpose:** Surface Claude Code notifications in the zjstatus bar — permission requests, idle "waiting for input" prompts, and background agent events (`agent_needs_input` / `agent_completed`, fired by background agents since CC v2.1.198).
 
 **Actions:**
-1. Exit silently if not inside zellij or jq is missing
-2. Parse `message` and optional `notification_type` from stdin JSON
-3. Map type to icon: `agent_completed` → ✅, `agent_needs_input` → 🔔, `permission*` → 🔐, default → 🔔
-4. Truncate message to 60 chars and send `zjstatus::notify::<icon> <message>` via zellij pipe
+1. Exit silently if not inside zellij, jq is missing, or stdin isn't valid JSON
+2. Parse `message` and optional `notification_type` from stdin JSON, truncating the message to 60 chars inside jq (codepoint-safe — bash slicing counts bytes under a C locale and can split multibyte chars)
+3. Map type to icon: `agent_completed` → ✅, `permission*` → 🔐, everything else (incl. `agent_needs_input`) → 🔔
+4. Send `zjstatus::notify::<icon> <message>` via zellij pipe
 
-The notify slot is shared with `zj-status.sh` (working/waiting); notifications intentionally overwrite the working indicator, and the next `UserPromptSubmit`/`Stop` restores it.
+The notify slot is shared with `zj-status.sh` (working/waiting); notifications intentionally overwrite the working indicator. A mid-turn notification stays visible until the turn ends (`Stop` clears the slot; the next `UserPromptSubmit` rewrites it).
 
 **Input JSON fields:** `session_id`, `cwd`, `message`, `notification_type` (background agent events only)
 
 **Output:** None (zellij pipe side effect only)
 
-**Exit code:** Always 0 (graceful degradation without zellij/jq).
+**Exit code:** Always 0 (graceful degradation without zellij/jq, and on malformed input).
 
 ---
 

--- a/home/.claude/hooks/notification.sh
+++ b/home/.claude/hooks/notification.sh
@@ -12,7 +12,8 @@
 #
 # The zjstatus notify slot is shared with zj-status.sh (working/waiting).
 # Overwriting the working indicator is intentional: a notification is
-# strictly more urgent, and the next UserPromptSubmit/Stop restores state.
+# strictly more urgent. A mid-turn notification stays visible until the
+# turn ends (Stop clears the slot; UserPromptSubmit rewrites it).
 
 set -euo pipefail
 
@@ -25,8 +26,11 @@ INPUT=$(cat)
 # Graceful degradation if jq is missing
 command -v jq &>/dev/null || exit 0
 
-MESSAGE=$(echo "$INPUT" | jq -r '.message // ""')
-NTYPE=$(echo "$INPUT" | jq -r '.notification_type // ""')
+# Truncate inside jq: bash ${MESSAGE:0:57} slices bytes under a C locale
+# (GUI-launched sessions), splitting multibyte chars; jq slices codepoints.
+# The `|| exit 0` guards keep the always-exit-0 contract on malformed stdin.
+MESSAGE=$(echo "$INPUT" | jq -r '.message // "" | if length > 60 then .[0:57] + "..." else . end' 2>/dev/null) || exit 0
+NTYPE=$(echo "$INPUT" | jq -r '.notification_type // ""' 2>/dev/null) || exit 0
 
 # Nothing to show
 [[ -z "$MESSAGE" ]] && exit 0
@@ -35,20 +39,13 @@ case "$NTYPE" in
     agent_completed)
         ICON="✅"
         ;;
-    agent_needs_input)
-        ICON="🔔"
-        ;;
-    permission_request | permission*)
+    permission*)
         ICON="🔐"
         ;;
     *)
+        # Includes agent_needs_input and untyped notifications
         ICON="🔔"
         ;;
 esac
-
-# Truncate so the status bar stays readable
-if ((${#MESSAGE} > 60)); then
-    MESSAGE="${MESSAGE:0:57}..."
-fi
 
 zellij pipe "zjstatus::notify::${ICON} ${MESSAGE}" 2>/dev/null || true

--- a/home/.claude/hooks/notification.sh
+++ b/home/.claude/hooks/notification.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Surface Claude Code notifications in the zjstatus bar
+#
+# Trigger: Notification. Fires when Claude Code sends a notification —
+# permission requests, idle "waiting for input" prompts, and background
+# agent events (notification_type: agent_needs_input / agent_completed,
+# added in CC v2.1.198).
+#
+# Input (via stdin): JSON with session_id, cwd, message, and (for
+# background agent events) notification_type.
+# Output: None (zellij pipe side effect only)
+#
+# The zjstatus notify slot is shared with zj-status.sh (working/waiting).
+# Overwriting the working indicator is intentional: a notification is
+# strictly more urgent, and the next UserPromptSubmit/Stop restores state.
+
+set -euo pipefail
+
+# Read input (must consume stdin before any exit)
+INPUT=$(cat)
+
+# Skip if not in zellij
+[[ -z "${ZELLIJ:-}" ]] && exit 0
+
+# Graceful degradation if jq is missing
+command -v jq &>/dev/null || exit 0
+
+MESSAGE=$(echo "$INPUT" | jq -r '.message // ""')
+NTYPE=$(echo "$INPUT" | jq -r '.notification_type // ""')
+
+# Nothing to show
+[[ -z "$MESSAGE" ]] && exit 0
+
+case "$NTYPE" in
+    agent_completed)
+        ICON="✅"
+        ;;
+    agent_needs_input)
+        ICON="🔔"
+        ;;
+    permission_request | permission*)
+        ICON="🔐"
+        ;;
+    *)
+        ICON="🔔"
+        ;;
+esac
+
+# Truncate so the status bar stays readable
+if ((${#MESSAGE} > 60)); then
+    MESSAGE="${MESSAGE:0:57}..."
+fi
+
+zellij pipe "zjstatus::notify::${ICON} ${MESSAGE}" 2>/dev/null || true

--- a/home/.claude/hooks/notification.sh
+++ b/home/.claude/hooks/notification.sh
@@ -35,17 +35,15 @@ NTYPE=$(echo "$INPUT" | jq -r '.notification_type // ""' 2>/dev/null) || exit 0
 # Nothing to show
 [[ -z "$MESSAGE" ]] && exit 0
 
-case "$NTYPE" in
-    agent_completed)
-        ICON="✅"
-        ;;
-    permission*)
-        ICON="🔐"
-        ;;
-    *)
-        # Includes agent_needs_input and untyped notifications
-        ICON="🔔"
-        ;;
-esac
+# Permission prompts arrive untyped (notification_type is set only for
+# background-agent events), so also key the padlock off the message text.
+if [[ "$NTYPE" == "agent_completed" ]]; then
+    ICON="✅"
+elif [[ "$NTYPE" == permission* || "$MESSAGE" == *[Pp]ermission* ]]; then
+    ICON="🔐"
+else
+    # Includes agent_needs_input and other untyped notifications
+    ICON="🔔"
+fi
 
 zellij pipe "zjstatus::notify::${ICON} ${MESSAGE}" 2>/dev/null || true

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -109,6 +109,16 @@
           }
         ]
       }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/notification.sh"
+          }
+        ]
+      }
     ]
   },
   "statusLine": {

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -85,7 +85,13 @@ elif [[ "$*" == *".team_name"* ]]; then
 elif [[ "$*" == *".notification_type"* ]]; then
     echo "$input" | grep -o '"notification_type":"[^"]*"' | cut -d'"' -f4 || echo ""
 elif [[ "$*" == *".message"* ]]; then
-    echo "$input" | grep -o '"message":"[^"]*"' | cut -d'"' -f4 || echo ""
+    # Emulate notification.sh's jq-side truncation filter (ASCII only)
+    m=$(echo "$input" | grep -o '"message":"[^"]*"' | cut -d'"' -f4) || m=""
+    if [[ "$*" == *"length > 60"* ]] && (( ${#m} > 60 )); then
+        echo "${m:0:57}..."
+    else
+        echo "$m"
+    fi
 elif [[ "$*" == *"-e"* ]] && [[ "$*" == *".event_id"* ]]; then
     # For jq -e '.event_id' checks - return success if event_id exists
     if echo "$input" | grep -q '"event_id"'; then
@@ -1039,8 +1045,8 @@ test_zj_status_consumes_stdin() {
 # notification.sh tests
 # ============================================================================
 
-# Fake zellij binary that records its arguments, for asserting pipe payloads.
-setup_fake_zellij() {
+# Mock zellij binary that records its arguments, for asserting pipe payloads.
+setup_mock_zellij() {
     ZJ_CAPTURE="$TEST_TMP/zj-capture.txt"
     : > "$ZJ_CAPTURE"
     cat > "$TEST_TMP/bin/zellij" << 'EOF'
@@ -1078,7 +1084,7 @@ test_notification_graceful_no_jq() {
 }
 
 test_notification_agent_completed_icon() {
-    setup_fake_zellij
+    setup_mock_zellij
 
     echo '{"session_id":"s1","message":"Background agent finished","notification_type":"agent_completed"}' \
         | ZELLIJ=1 bash "$HOOKS_DIR/notification.sh"
@@ -1087,7 +1093,7 @@ test_notification_agent_completed_icon() {
 }
 
 test_notification_needs_input_icon() {
-    setup_fake_zellij
+    setup_mock_zellij
 
     echo '{"message":"Agent needs your input","notification_type":"agent_needs_input"}' \
         | ZELLIJ=1 bash "$HOOKS_DIR/notification.sh"
@@ -1096,7 +1102,7 @@ test_notification_needs_input_icon() {
 }
 
 test_notification_default_icon() {
-    setup_fake_zellij
+    setup_mock_zellij
 
     echo '{"message":"Waiting for your input"}' \
         | ZELLIJ=1 bash "$HOOKS_DIR/notification.sh"
@@ -1105,7 +1111,7 @@ test_notification_default_icon() {
 }
 
 test_notification_empty_message_no_pipe() {
-    setup_fake_zellij
+    setup_mock_zellij
 
     echo '{"notification_type":"agent_completed"}' \
         | ZELLIJ=1 bash "$HOOKS_DIR/notification.sh"
@@ -1114,7 +1120,7 @@ test_notification_empty_message_no_pipe() {
 }
 
 test_notification_truncates_long_message() {
-    setup_fake_zellij
+    setup_mock_zellij
 
     local long_msg
     long_msg=$(printf 'x%.0s' {1..80})
@@ -1124,6 +1130,18 @@ test_notification_truncates_long_message() {
     # 57 chars + "..." — the 80-char original must not appear
     grep -qF "$(printf 'x%.0s' {1..57})..." "$ZJ_CAPTURE" \
         && ! grep -qF "$long_msg" "$ZJ_CAPTURE"
+}
+
+test_notification_malformed_json_exit_zero() {
+    # Malformed stdin must not break the always-exit-0 contract (jq parse
+    # errors are guarded) and must not pipe anything to zellij
+    setup_mock_zellij
+
+    local output
+    local exit_code=0
+    output=$(echo 'not json at all' | ZELLIJ=1 bash "$HOOKS_DIR/notification.sh" 2>&1) || exit_code=$?
+
+    [[ $exit_code -eq 0 ]] && [[ -z "$output" ]] && [[ ! -s "$ZJ_CAPTURE" ]]
 }
 
 # ============================================================================
@@ -1804,6 +1822,7 @@ main() {
     run_test "integration: default icon (no type)" "test_notification_default_icon"
     run_test "integration: empty message is a no-op" "test_notification_empty_message_no_pipe"
     run_test "integration: truncates long messages" "test_notification_truncates_long_message"
+    run_test "graceful degradation (malformed JSON)" "test_notification_malformed_json_exit_zero"
     echo ""
 
     echo "=== teammate-idle.sh ==="

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -1110,6 +1110,17 @@ test_notification_default_icon() {
     grep -qF "pipe zjstatus::notify::🔔 Waiting for your input" "$ZJ_CAPTURE"
 }
 
+test_notification_untyped_permission_icon() {
+    # Permission prompts arrive without notification_type — the padlock
+    # must key off the message text
+    setup_mock_zellij
+
+    echo '{"message":"Claude needs your permission to use Bash"}' \
+        | ZELLIJ=1 bash "$HOOKS_DIR/notification.sh"
+
+    grep -qF "pipe zjstatus::notify::🔐 Claude needs your permission to use Bash" "$ZJ_CAPTURE"
+}
+
 test_notification_empty_message_no_pipe() {
     setup_mock_zellij
 
@@ -1820,6 +1831,7 @@ main() {
     run_test "integration: agent_completed icon" "test_notification_agent_completed_icon"
     run_test "integration: agent_needs_input icon" "test_notification_needs_input_icon"
     run_test "integration: default icon (no type)" "test_notification_default_icon"
+    run_test "integration: untyped permission prompt gets padlock" "test_notification_untyped_permission_icon"
     run_test "integration: empty message is a no-op" "test_notification_empty_message_no_pipe"
     run_test "integration: truncates long messages" "test_notification_truncates_long_message"
     run_test "graceful degradation (malformed JSON)" "test_notification_malformed_json_exit_zero"

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -82,6 +82,10 @@ elif [[ "$*" == *".teammate_name"* ]]; then
     echo "$input" | grep -o '"teammate_name":"[^"]*"' | cut -d'"' -f4 || echo ""
 elif [[ "$*" == *".team_name"* ]]; then
     echo "$input" | grep -o '"team_name":"[^"]*"' | cut -d'"' -f4 || echo ""
+elif [[ "$*" == *".notification_type"* ]]; then
+    echo "$input" | grep -o '"notification_type":"[^"]*"' | cut -d'"' -f4 || echo ""
+elif [[ "$*" == *".message"* ]]; then
+    echo "$input" | grep -o '"message":"[^"]*"' | cut -d'"' -f4 || echo ""
 elif [[ "$*" == *"-e"* ]] && [[ "$*" == *".event_id"* ]]; then
     # For jq -e '.event_id' checks - return success if event_id exists
     if echo "$input" | grep -q '"event_id"'; then
@@ -1032,6 +1036,97 @@ test_zj_status_consumes_stdin() {
 }
 
 # ============================================================================
+# notification.sh tests
+# ============================================================================
+
+# Fake zellij binary that records its arguments, for asserting pipe payloads.
+setup_fake_zellij() {
+    ZJ_CAPTURE="$TEST_TMP/zj-capture.txt"
+    : > "$ZJ_CAPTURE"
+    cat > "$TEST_TMP/bin/zellij" << 'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >> "${ZJ_CAPTURE:?}"
+EOF
+    chmod +x "$TEST_TMP/bin/zellij"
+    export ZJ_CAPTURE
+}
+
+test_notification_syntax() {
+    bash -n "$HOOKS_DIR/notification.sh"
+}
+
+test_notification_graceful_no_zellij_env() {
+    local output
+    local exit_code=0
+    output=$(echo '{"message":"hi"}' | env -u ZELLIJ bash "$HOOKS_DIR/notification.sh" 2>&1) || exit_code=$?
+
+    [[ $exit_code -eq 0 ]] && [[ -z "$output" ]]
+}
+
+test_notification_graceful_no_jq() {
+    # ZELLIJ set but no jq in PATH: must exit 0 silently before calling zellij
+    local no_jq_dir="$TEST_TMP/no-jq-notification"
+    mkdir -p "$no_jq_dir"
+    ln -sf "$(type -P cat)" "$no_jq_dir/cat"
+    ln -sf "$(type -P bash)" "$no_jq_dir/bash"
+
+    local output
+    local exit_code=0
+    output=$(echo '{"message":"hi"}' | env -i PATH="$no_jq_dir" HOME="$HOME" ZELLIJ=1 bash "$HOOKS_DIR/notification.sh" 2>&1) || exit_code=$?
+
+    [[ $exit_code -eq 0 ]] && [[ -z "$output" ]]
+}
+
+test_notification_agent_completed_icon() {
+    setup_fake_zellij
+
+    echo '{"session_id":"s1","message":"Background agent finished","notification_type":"agent_completed"}' \
+        | ZELLIJ=1 bash "$HOOKS_DIR/notification.sh"
+
+    grep -qF "pipe zjstatus::notify::✅ Background agent finished" "$ZJ_CAPTURE"
+}
+
+test_notification_needs_input_icon() {
+    setup_fake_zellij
+
+    echo '{"message":"Agent needs your input","notification_type":"agent_needs_input"}' \
+        | ZELLIJ=1 bash "$HOOKS_DIR/notification.sh"
+
+    grep -qF "pipe zjstatus::notify::🔔 Agent needs your input" "$ZJ_CAPTURE"
+}
+
+test_notification_default_icon() {
+    setup_fake_zellij
+
+    echo '{"message":"Waiting for your input"}' \
+        | ZELLIJ=1 bash "$HOOKS_DIR/notification.sh"
+
+    grep -qF "pipe zjstatus::notify::🔔 Waiting for your input" "$ZJ_CAPTURE"
+}
+
+test_notification_empty_message_no_pipe() {
+    setup_fake_zellij
+
+    echo '{"notification_type":"agent_completed"}' \
+        | ZELLIJ=1 bash "$HOOKS_DIR/notification.sh"
+
+    [[ ! -s "$ZJ_CAPTURE" ]]
+}
+
+test_notification_truncates_long_message() {
+    setup_fake_zellij
+
+    local long_msg
+    long_msg=$(printf 'x%.0s' {1..80})
+    echo "{\"message\":\"$long_msg\"}" \
+        | ZELLIJ=1 bash "$HOOKS_DIR/notification.sh"
+
+    # 57 chars + "..." — the 80-char original must not appear
+    grep -qF "$(printf 'x%.0s' {1..57})..." "$ZJ_CAPTURE" \
+        && ! grep -qF "$long_msg" "$ZJ_CAPTURE"
+}
+
+# ============================================================================
 # session-start.sh cache pre-population tests
 # ============================================================================
 
@@ -1698,6 +1793,17 @@ main() {
     run_test "syntax check" "test_zj_status_syntax"
     run_test "graceful degradation (no ZELLIJ env)" "test_zj_status_graceful_no_zellij_env"
     run_test "consumes stdin" "test_zj_status_consumes_stdin"
+    echo ""
+
+    echo "=== notification.sh ==="
+    run_test "syntax check" "test_notification_syntax"
+    run_test "graceful degradation (no ZELLIJ env)" "test_notification_graceful_no_zellij_env"
+    run_test "graceful degradation (no jq)" "test_notification_graceful_no_jq"
+    run_test "integration: agent_completed icon" "test_notification_agent_completed_icon"
+    run_test "integration: agent_needs_input icon" "test_notification_needs_input_icon"
+    run_test "integration: default icon (no type)" "test_notification_default_icon"
+    run_test "integration: empty message is a no-op" "test_notification_empty_message_no_pipe"
+    run_test "integration: truncates long messages" "test_notification_truncates_long_message"
     echo ""
 
     echo "=== teammate-idle.sh ==="


### PR DESCRIPTION
Applies the official ["Getting started with loops"](https://claude.com/blog/getting-started-with-loops) guidance and Claude Code changes since the last workflow review (~v2.1.7x → v2.1.202).

## Workflow updates

- **CLAUDE.md**: new "Loops & Automation" section — decision framework for turn-based vs `/goal` vs `/loop` vs `/schedule` Routines vs dynamic workflows, with deterministic-stop-condition and events-over-polling guidance
- **/work**: offers `/goal` for multi-round review→fix and CI→fix checkpoint cycles; terminology aligned with the current task system (TaskCreate/TaskList)
- **/pr-review local**: built-in `code-review` skill (multi-agent, adversarial verification) as the primary engine, effort scaled to diff size; plugin agent kept as fallback
- **/watch-ci**: `/loop 5m` fallback if the background watch dies
- **improve-workflow agent**: new "Loop Opportunities" reflection step — flags repeated fix-verify cycles, timer polling, and recurring maintenance as `/goal`, `/loop`, or `/schedule` candidates

## New automation

- **hooks/notification.sh**: surfaces `Notification` events in the zjstatus bar — ✅ `agent_completed`, 🔐 `permission*`, 🔔 everything else. Truncates inside jq (codepoint-safe), guarded against malformed stdin, shares the notify slot with `zj-status.sh`. Registered in settings.json.
- **/schedule-audits**: creates a weekly `weekly-audit-<repo>` Routine (Mon 09:00) running the `audit-*` agents unattended — observe-only, files issues, publishes `improvement_suggested` to the event bus. `status`/`off` modes manage it.
- **hooks/README.md**: corrected `TaskCreated`/`TaskCompleted` docs (general task system, not Agent-Teams-only); new hook documented + lifecycle diagram updated.

## Validation

- `make check` green: shellcheck, syntax, 99/99 hook tests (9 new for notification.sh incl. mock-zellij payload capture, no-jq/no-zellij/malformed-JSON degradation, truncation), 35/35 bootstrap tests
- Hook exercised directly against fixture JSON: all icon paths, empty-message no-op, malformed-input exit-0, and multibyte truncation under a C locale verified byte-level
- Self-reviewed via 8-angle adversarially-verified code-review pass; two confirmed bugs (jq parse failure exit code, byte-level truncation splitting multibyte chars) fixed in the final commit

**Post-merge**: run `./bootstrap.sh -f` to symlink the new hook. The `notification_type` field name for background-agent events is worth a glance at the zjstatus bar the first time a background agent finishes — unknown types degrade to 🔔.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrBLzQixo3zx8wSHVSGUXS

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrBLzQixo3zx8wSHVSGUXS)_