### PR TITLE
fix(bootstrap): re-exec after a pull rewrites the script

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,6 +5,12 @@ set -euo pipefail
 # Bootstrap Script - Install Dotfiles
 # ==============================================================================
 
+# Capture our own absolute path and argv before the cd below, so pull_latest can
+# re-exec us after a pull rewrites this file. Resolve with `pwd -P` so a run via
+# a symlink still points at the physical script.
+BOOTSTRAP_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/$(basename "${BASH_SOURCE[0]}")"
+BOOTSTRAP_ARGS=("$@")
+
 # Change to the dotfiles directory
 cd "$(dirname "${BASH_SOURCE[0]}")";
 
@@ -460,9 +466,36 @@ cleanup_legacy_cron() {
 	fi
 }
 
+# Pull, then restart if the pull rewrote this script.
+#
+# Bash reads a script lazily, by byte offset, as it executes. `git pull` rewrites
+# bootstrap.sh in place whenever an update touches it, which shifts the
+# interpreter's next read into unrelated content — the run then derails silently,
+# with no error and no exit code. Observed on 2026-08-02: a `-p` run stopped right
+# after `brew bundle` and never reached sync_dotfiles, even though the brew call is
+# wrapped in `|| echo "...(continuing)"` that never printed. The code still
+# executing was not the code on disk.
+#
+# Re-exec'ing hands the rest of the run to a fresh interpreter reading the new
+# file from byte zero. It happens inside this function, which bash has already
+# parsed in full, so we get out before the corrupted read can occur.
 pull_latest() {
+	if [[ -n "${DOTFILES_BOOTSTRAP_REEXECED:-}" ]]; then
+		echo "Already pulled before restarting; skipping."
+		return 0
+	fi
+
 	echo "Pulling latest changes from origin/main..."
+	local before after
+	before="$(cksum < "$BOOTSTRAP_SCRIPT")"
 	git pull origin main
+	after="$(cksum < "$BOOTSTRAP_SCRIPT")"
+
+	if [[ "$before" != "$after" ]]; then
+		echo "bootstrap.sh was updated by the pull — restarting with the new version..."
+		export DOTFILES_BOOTSTRAP_REEXECED=1
+		exec "$BOOTSTRAP_SCRIPT" ${BOOTSTRAP_ARGS[@]+"${BOOTSTRAP_ARGS[@]}"}
+	fi
 }
 
 prompt_ai_install() {
@@ -1275,6 +1308,10 @@ sync_dotfiles() {
 # ==============================================================================
 # Main Execution
 # ==============================================================================
+
+# Tests source this file to exercise individual functions. `return` is legal at
+# the top level of a sourced script and stops here, before any install work.
+[[ "${BOOTSTRAP_SOURCE_ONLY:-}" == "1" ]] && return 0
 
 # Parse arguments
 FORCE=false

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -481,6 +481,9 @@ cleanup_legacy_cron() {
 # parsed in full, so we get out before the corrupted read can occur.
 pull_latest() {
 	if [[ -n "${DOTFILES_BOOTSTRAP_REEXECED:-}" ]]; then
+		# Done its job — drop it so it doesn't ride along into brew, npm,
+		# launchctl, .macos, or any nested bootstrap run.
+		unset DOTFILES_BOOTSTRAP_REEXECED
 		echo "Already pulled before restarting; skipping."
 		return 0
 	fi
@@ -1311,7 +1314,14 @@ sync_dotfiles() {
 
 # Tests source this file to exercise individual functions. `return` is legal at
 # the top level of a sourced script and stops here, before any install work.
-[[ "${BOOTSTRAP_SOURCE_ONLY:-}" == "1" ]] && return 0
+#
+# The BASH_SOURCE test keeps this to genuinely-sourced runs. `return` from an
+# *executed* script is an error that set -e turns into an abort, so without it a
+# stray BOOTSTRAP_SOURCE_ONLY=1 in the environment would break a normal install —
+# including the re-exec'd process in pull_latest, which inherits the environment.
+if [[ "${BOOTSTRAP_SOURCE_ONLY:-}" == "1" && "${BASH_SOURCE[0]}" != "$0" ]]; then
+	return 0
+fi
 
 # Parse arguments
 FORCE=false

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -495,6 +495,94 @@ test_launch_agent_idempotent_on_unchanged_plist() {
 }
 
 # ============================================================================
+# Self-update re-exec tests
+# ============================================================================
+#
+# `git pull` can rewrite bootstrap.sh mid-run. Bash reads scripts lazily by byte
+# offset, so the interpreter then reads from a shifted position in new content and
+# the run derails silently. pull_latest must detect that and re-exec.
+#
+# These load the REAL pull_latest by sourcing bootstrap.sh with BOOTSTRAP_SOURCE_ONLY,
+# against a sandboxed copy plus a stubbed `git` that simulates the rewrite.
+
+# Build a sandbox: a copy of bootstrap.sh, a `git` stub, and a runner that sources
+# the copy and calls pull_latest. $1 = "rewrite" (pull mutates the script) or
+# "noop". Echoes the sandbox dir.
+_make_reexec_sandbox() {
+    local mode="$1"
+    local dir stub
+    dir=$(mktemp -d); stub="$dir/bin"; mkdir -p "$stub"
+    cp "$BOOTSTRAP" "$dir/bootstrap.sh"
+    chmod +x "$dir/bootstrap.sh"
+
+    # What `git pull` leaves behind in the rewrite case: a stand-in that records
+    # the argv it was re-exec'd with. Reaching this proves the exec happened.
+    {
+        printf '#!/bin/bash\n'
+        printf 'echo "$@" > "%s/reexec.args"\n' "$dir"
+    } > "$dir/marker.sh"
+    chmod +x "$dir/marker.sh"
+
+    {
+        printf '#!/bin/bash\n'
+        printf 'echo "$@" >> "%s/git.calls"\n' "$dir"
+        if [[ "$mode" == "rewrite" ]]; then
+            printf '[[ "$1" == "pull" ]] && cp "%s/marker.sh" "%s/bootstrap.sh"\n' "$dir" "$dir"
+        fi
+        printf 'exit 0\n'
+    } > "$stub/git"
+    chmod +x "$stub/git"
+
+    {
+        printf '#!/bin/bash\n'
+        printf 'set -euo pipefail\n'
+        printf 'export BOOTSTRAP_SOURCE_ONLY=1\n'
+        printf 'source "%s/bootstrap.sh" --force --pull\n' "$dir"
+        printf 'unset BOOTSTRAP_SOURCE_ONLY\n'
+        # Prepend the stub AFTER sourcing: bootstrap.sh evals `brew shellenv`,
+        # which puts /opt/homebrew/bin in front and would shadow our fake git.
+        printf 'export PATH="%s:$PATH"\n' "$stub"
+        printf 'pull_latest\n'
+    } > "$dir/run.sh"
+
+    echo "$dir"
+}
+
+test_pull_latest_reexecs_when_pull_rewrites_script() {
+    local dir; dir=$(_make_reexec_sandbox rewrite)
+    PATH="$dir/bin:$PATH" bash "$dir/run.sh" >/dev/null 2>&1 || true
+    local ok=0
+    [[ -f "$dir/reexec.args" ]] || ok=1                              # re-exec happened
+    grep -q -- '--force --pull' "$dir/reexec.args" 2>/dev/null || ok=1  # argv preserved
+    rm -rf "$dir"
+    return $ok
+}
+
+test_pull_latest_no_reexec_when_script_unchanged() {
+    local dir rc=0; dir=$(_make_reexec_sandbox noop)
+    PATH="$dir/bin:$PATH" bash "$dir/run.sh" >/dev/null 2>&1 || rc=$?
+    local ok=0
+    [[ "$rc" -eq 0 ]] || ok=1                    # returned normally, run continues
+    [[ -e "$dir/reexec.args" ]] && ok=1          # did NOT re-exec
+    grep -q 'pull origin main' "$dir/git.calls" 2>/dev/null || ok=1   # did still pull
+    rm -rf "$dir"
+    return $ok
+}
+
+# The re-exec'd process must not pull again — otherwise it re-detects a change
+# against the pre-pull checksum and loops.
+test_pull_latest_skips_pull_after_reexec() {
+    local dir rc=0; dir=$(_make_reexec_sandbox rewrite)
+    DOTFILES_BOOTSTRAP_REEXECED=1 PATH="$dir/bin:$PATH" bash "$dir/run.sh" >/dev/null 2>&1 || rc=$?
+    local ok=0
+    [[ "$rc" -eq 0 ]] || ok=1
+    [[ -e "$dir/git.calls" ]] && ok=1            # git never invoked
+    [[ -e "$dir/reexec.args" ]] && ok=1          # no second exec
+    rm -rf "$dir"
+    return $ok
+}
+
+# ============================================================================
 # Run all tests
 # ============================================================================
 
@@ -554,6 +642,12 @@ main() {
     run_test "sysload-writer tolerates top failure" "test_sysload_writer_tolerates_top_failure"
     run_test "launch agent substitutes __HOME__ and reloads" "test_launch_agent_substitutes_home"
     run_test "launch agent idempotent on unchanged plist" "test_launch_agent_idempotent_on_unchanged_plist"
+    echo ""
+
+    echo "=== self-update re-exec ==="
+    run_test "re-execs when pull rewrites bootstrap.sh" "test_pull_latest_reexecs_when_pull_rewrites_script"
+    run_test "no re-exec when script unchanged" "test_pull_latest_no_reexec_when_script_unchanged"
+    run_test "skips pull after re-exec (no loop)" "test_pull_latest_skips_pull_after_reexec"
     echo ""
 
     # Summary

--- a/tests/test-bootstrap.sh
+++ b/tests/test-bootstrap.sh
@@ -582,6 +582,30 @@ test_pull_latest_skips_pull_after_reexec() {
     return $ok
 }
 
+# The re-exec marker is exported, so without an unset it rides along into every
+# child bootstrap spawns (brew, npm, launchctl, .macos) and would make a nested
+# bootstrap run silently skip its own pull.
+test_pull_latest_unsets_reexec_marker() {
+    local dir; dir=$(_make_reexec_sandbox noop)
+    printf 'echo "marker=[${DOTFILES_BOOTSTRAP_REEXECED:-}]" > "%s/marker.state"\n' "$dir" >> "$dir/run.sh"
+    DOTFILES_BOOTSTRAP_REEXECED=1 bash "$dir/run.sh" >/dev/null 2>&1 || true
+    local ok=0
+    grep -q 'marker=\[\]' "$dir/marker.state" 2>/dev/null || ok=1
+    rm -rf "$dir"
+    return $ok
+}
+
+# BOOTSTRAP_SOURCE_ONLY is only meaningful when sourced. It is also inherited by
+# the re-exec'd process, so if a stray value in the environment could reach the
+# top-level `return`, bash would error ("can only `return' from a function or
+# sourced script") and set -e would abort the install. An executed run must
+# ignore it entirely.
+test_source_only_ignored_when_executed() {
+    local out rc=0
+    out=$(BOOTSTRAP_SOURCE_ONLY=1 "$BOOTSTRAP" --help 2>&1) || rc=$?
+    [[ "$rc" -eq 0 ]] && echo "$out" | grep -q "Usage:"
+}
+
 # ============================================================================
 # Run all tests
 # ============================================================================
@@ -648,6 +672,8 @@ main() {
     run_test "re-execs when pull rewrites bootstrap.sh" "test_pull_latest_reexecs_when_pull_rewrites_script"
     run_test "no re-exec when script unchanged" "test_pull_latest_no_reexec_when_script_unchanged"
     run_test "skips pull after re-exec (no loop)" "test_pull_latest_skips_pull_after_reexec"
+    run_test "unsets re-exec marker so children don't inherit it" "test_pull_latest_unsets_reexec_marker"
+    run_test "BOOTSTRAP_SOURCE_ONLY ignored when executed" "test_source_only_ignored_when_executed"
     echo ""
 
     # Summary


### PR DESCRIPTION
## Problem

`./bootstrap.sh -p` can abort silently partway through.

`pull_latest` runs `git pull origin main`, which rewrites `bootstrap.sh` in place whenever an update touches it. Bash reads scripts lazily by byte offset, so the interpreter's next read lands at a shifted position in new content and the run derails — no error, no exit code, no clue in the output.

Observed on 2026-08-02 while updating this machine: a `-p` run stopped right after `brew bundle` and never reached `sync_dotfiles`, leaving `~/.macos` unlinked. The tell was that the brew call is wrapped in `|| echo "…(continuing)"` and **that warning never printed** — the code still executing was not the code on disk. `cbe9b2d` had touched `bootstrap.sh` in that same pull.

This is silent and non-deterministic: it only bites when an update happens to change `bootstrap.sh`, which is exactly the run where you least want a half-finished install.

## Fix

`pull_latest` checksums the script around the pull. On a change, it re-execs, handing the rest of the run to a fresh interpreter reading the new file from byte zero.

- The `exec` happens *inside* `pull_latest`, which bash has already parsed in full, so we get out before the corrupted read can occur.
- `DOTFILES_BOOTSTRAP_REEXECED` guards the second pass so it doesn't pull again and loop.
- `BOOTSTRAP_SCRIPT` / `BOOTSTRAP_ARGS` are captured at the top, before the `cd`, so the re-exec targets the physical script (`pwd -P`, so a symlinked invocation still resolves) with the original argv intact.

## Testing

Adds `BOOTSTRAP_SOURCE_ONLY` — one line before the main block. `return` is legal at the top level of a sourced script, so tests get every function definition with zero install side effects, without wrapping the main block in an `if` or duplicating logic into a mock.

Three behavioral tests exercise the **real** `pull_latest` against a sandboxed copy of `bootstrap.sh` and a stubbed `git`:

| Test | Asserts |
|---|---|
| re-execs when pull rewrites bootstrap.sh | exec happened, original argv preserved |
| no re-exec when script unchanged | returns normally, still pulled |
| skips pull after re-exec | git never invoked, no second exec |

**All three fail when `bootstrap.sh` is reverted** (verified by stashing just that file).

`make check` passes: shellcheck clean, 112 hook tests, 42 bootstrap tests. `./bootstrap.sh -f` still runs clean (exit 0) with the source-only guard in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WfpypRTFbZ7eZTWLyJX9y