### PR TITLE
chore(claude): set default model to opus

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -10,7 +10,7 @@
     "allow": [],
     "defaultMode": "bypassPermissions"
   },
-  "model": "fable",
+  "model": "opus",
   "hooks": {
     "UserPromptSubmit": [
       {
@@ -147,9 +147,9 @@
     "frontend-design@claude-plugins-official": true
   },
   "fastMode": true,
+  "tui": "fullscreen",
   "skipDangerousModePermissionPrompt": true,
   "theme": "auto",
   "remoteControlAtStartup": true,
-  "agentPushNotifEnabled": true,
-  "tui": "fullscreen"
+  "agentPushNotifEnabled": true
 }


### PR DESCRIPTION
## What

Flips `home/.claude/settings.json` back to `"model": "opus"`.

#325 set the default to `"fable"`. This switches it back via `/model`, which writes through the `~/.claude/settings.json` symlink into the tracked file — so the change shows up as a working-tree diff rather than something typed by hand.

Also picks up a cosmetic reordering of the `tui` key that Claude Code's settings writer emitted at the same time.

## Note

This is the recurring symlink round-trip: tools that write their own config through a symlinked dotfile will surface those writes as repo diffs. Committing it is the intended path — the alternative is the file sitting dirty indefinitely and getting swept into an unrelated commit later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WfpypRTFbZ7eZTWLyJX9y