### PR TITLE
Consume agent-event-bus session attribution (#128) and signal levels (#129) from the hooks

### DIFF
--- a/home/.claude/hooks/README.md
+++ b/home/.claude/hooks/README.md
@@ -77,7 +77,10 @@ Session End / Agent Teams
 **Actions:**
 1. Rename zellij tab to directory name (with worktree format: `repo (branch)`)
 2. Register with event bus using `agent-event-bus-cli`
-3. Fetch recent events (last 20, newest first)
+3. Fetch recent events (last 20, newest first) using the server-side noise
+   policy (`--min-level info`, agent-event-bus#129); if the installed CLI
+   predates the flag the call fails silently, so the hook falls back once to
+   the legacy client-side `--exclude` denylist (deploy-ordering safety)
 4. If resuming after compaction, restore WIP checkpoint
 
 **Input JSON fields:** `session_id`, `transcript_path`, `cwd`, `permission_mode`, `source`
@@ -293,6 +296,15 @@ Two hooks read the agent-event-bus and surface events to the agent:
 
 - **`prompt-events.sh`** (`UserPromptSubmit`) — fires when the human types. Consumes new events and injects them as `<recent-events>`.
 - **`drain-directed-events.sh`** (`Stop`) — fires at end-of-turn. Peeks for *directed* events and blocks once to surface them if any are waiting, closing the gap where a session goes idle without seeing a DM / help request.
+
+**Noise policy is deliberately split.** `session-start.sh` filters server-side
+with `--min-level info` (non-consuming read, so a coarser filter only costs
+noise), while both drain-path hooks keep the client-side `EB_EXCLUDE` denylist:
+the drain *consumes* exactly the window it peeked, and a server-side filter
+would advance the cursor past events the client never saw. See the rationale
+comment in `lib/eventbus-collect.sh` before "unifying" the drain onto
+`--min-level` (agent-event-bus#134 tracks the cursor-ack primitive that would
+make that safe).
 
 ### Shared library (`lib/eventbus-collect.sh`)
 

--- a/home/.claude/hooks/lib/eventbus-collect.sh
+++ b/home/.claude/hooks/lib/eventbus-collect.sh
@@ -31,6 +31,17 @@ EB_URL_ARGS=()
 [[ -n "${AGENT_EVENT_BUS_URL:-}" ]] && EB_URL_ARGS=(--url "$AGENT_EVENT_BUS_URL")
 
 # Canonical denylist of noisy event types. Both hooks MUST use this one list.
+#
+# Why not the bus's server-side --min-level (agent-event-bus#129)? The drain
+# hook's bounded consume (peek N filtered events, then consume with
+# --limit N) relies on --exclude being CLIENT-side: the server's --limit and
+# the peeked count then refer to the same raw event window. --min-level
+# filters server-side BUT the raw batch still advances the cursor, so a
+# consume bounded to the filtered count would advance past a different raw
+# window than the peek saw - risking consumed-but-never-surfaced events.
+# Migrate to --min-level only once the bus grows an explicit cursor-ack
+# primitive (advance-to <id>); until then this list must stay in sync with
+# the bus's lifecycle level (EVENT_TYPE_SIGNAL_LEVELS in server.py).
 EB_EXCLUDE="session_registered,session_unregistered,ci_watching,task_started,ci_rerun,parallel_work_started"
 
 # Graceful-degradation guard: caller should `eb_have_deps || exit 0`.

--- a/home/.claude/hooks/session-start.sh
+++ b/home/.claude/hooks/session-start.sh
@@ -96,10 +96,13 @@ fi
 # - "repo:<name>" - repo-specific coordination
 # - "machine:<hostname>" - local machine coordination
 # - "session:<id>" - direct messages (if resumed with same session_id)
+# --min-level info drops lifecycle churn (session_registered, ci_watching,
+# task_started, ...) server-side - one canonical noise policy on the bus
+# (agent-event-bus#129) instead of a local denylist.
 EVENTS=$(agent-event-bus-cli ${URL_ARGS[@]+"${URL_ARGS[@]}"} events \
     --session-id "$SESSION_ID" \
     --order desc \
-    --exclude session_registered,session_unregistered \
+    --min-level info \
     --timeout 200 \
     --limit 20 \
     2>/dev/null) || true

--- a/home/.claude/hooks/session-start.sh
+++ b/home/.claude/hooks/session-start.sh
@@ -107,6 +107,20 @@ EVENTS=$(agent-event-bus-cli ${URL_ARGS[@]+"${URL_ARGS[@]}"} events \
     --limit 20 \
     2>/dev/null) || true
 
+# Version-skew fallback: a CLI predating --min-level (agent-event-bus#129)
+# errors out with stderr suppressed, leaving EVENTS empty - the CLI prints
+# "No events" when there are genuinely none, so empty means the flag wasn't
+# understood; retry once with the legacy client-side denylist.
+if [[ -z "$EVENTS" ]]; then
+    EVENTS=$(agent-event-bus-cli ${URL_ARGS[@]+"${URL_ARGS[@]}"} events \
+        --session-id "$SESSION_ID" \
+        --order desc \
+        --exclude session_registered,session_unregistered \
+        --timeout 200 \
+        --limit 20 \
+        2>/dev/null) || true
+fi
+
 # Output events in XML tags (interpretation guidance is in CLAUDE.md)
 if [[ -n "$EVENTS" && "$EVENTS" != "No events" && "$EVENTS" != "No new events" ]]; then
     echo "<recent-events>"

--- a/home/.claude/hooks/session-start.sh
+++ b/home/.claude/hooks/session-start.sh
@@ -99,14 +99,22 @@ fi
 # --min-level info drops lifecycle churn (session_registered, ci_watching,
 # task_started, ...) server-side - one canonical noise policy on the bus
 # (agent-event-bus#129) instead of a local denylist.
+#
+# The primary fetch and the version-skew fallback below differ only in
+# their filter flag - one shared invocation keeps --timeout/--limit (and
+# the stderr suppression) from drifting between the two call sites.
+fetch_events() {
+    agent-event-bus-cli ${URL_ARGS[@]+"${URL_ARGS[@]}"} events \
+        --session-id "$SESSION_ID" \
+        --order desc \
+        "$@" \
+        --timeout 200 \
+        --limit 20 \
+        2>/dev/null
+}
+
 FETCH_RC=0
-EVENTS=$(agent-event-bus-cli ${URL_ARGS[@]+"${URL_ARGS[@]}"} events \
-    --session-id "$SESSION_ID" \
-    --order desc \
-    --min-level info \
-    --timeout 200 \
-    --limit 20 \
-    2>/dev/null) || FETCH_RC=$?
+EVENTS=$(fetch_events --min-level info) || FETCH_RC=$?
 
 # Version-skew fallback: a CLI predating --min-level (agent-event-bus#129)
 # rejects the flag with an argparse usage error - exit 2, stderr suppressed,
@@ -116,13 +124,7 @@ EVENTS=$(agent-event-bus-cli ${URL_ARGS[@]+"${URL_ARGS[@]}"} events \
 # ~200ms timeout. A flag-aware CLI prints "No events" when there are
 # genuinely none, so empty-with-success never fires the fallback either.
 if [[ -z "$EVENTS" && $FETCH_RC -eq 2 ]]; then
-    EVENTS=$(agent-event-bus-cli ${URL_ARGS[@]+"${URL_ARGS[@]}"} events \
-        --session-id "$SESSION_ID" \
-        --order desc \
-        --exclude session_registered,session_unregistered \
-        --timeout 200 \
-        --limit 20 \
-        2>/dev/null) || true
+    EVENTS=$(fetch_events --exclude session_registered,session_unregistered) || true
 fi
 
 # Output events in XML tags (interpretation guidance is in CLAUDE.md)

--- a/home/.claude/hooks/session-start.sh
+++ b/home/.claude/hooks/session-start.sh
@@ -99,19 +99,23 @@ fi
 # --min-level info drops lifecycle churn (session_registered, ci_watching,
 # task_started, ...) server-side - one canonical noise policy on the bus
 # (agent-event-bus#129) instead of a local denylist.
+FETCH_RC=0
 EVENTS=$(agent-event-bus-cli ${URL_ARGS[@]+"${URL_ARGS[@]}"} events \
     --session-id "$SESSION_ID" \
     --order desc \
     --min-level info \
     --timeout 200 \
     --limit 20 \
-    2>/dev/null) || true
+    2>/dev/null) || FETCH_RC=$?
 
 # Version-skew fallback: a CLI predating --min-level (agent-event-bus#129)
-# errors out with stderr suppressed, leaving EVENTS empty - the CLI prints
-# "No events" when there are genuinely none, so empty means the flag wasn't
-# understood; retry once with the legacy client-side denylist.
-if [[ -z "$EVENTS" ]]; then
+# rejects the flag with an argparse usage error - exit 2, stderr suppressed,
+# EVENTS empty - so retry once with the legacy client-side denylist. Exit 2
+# discriminates that from a bus that is down or timed out (exit 1), where a
+# retry can't help and would make every offline session start pay a second
+# ~200ms timeout. A flag-aware CLI prints "No events" when there are
+# genuinely none, so empty-with-success never fires the fallback either.
+if [[ -z "$EVENTS" && $FETCH_RC -eq 2 ]]; then
     EVENTS=$(agent-event-bus-cli ${URL_ARGS[@]+"${URL_ARGS[@]}"} events \
         --session-id "$SESSION_ID" \
         --order desc \

--- a/home/.exports
+++ b/home/.exports
@@ -7,6 +7,17 @@
 #   GEMINI_API_KEY - Required for Gemini API access
 #   AGENT_EVENT_BUS_URL - URL for event bus MCP server (e.g., https://host/agent-event-bus/mcp)
 
+# Claude Code shells (subagents, workflow steps, Bash tool calls): attribute
+# agent-event-bus publishes/polls to the owning session instead of "anonymous"
+# (agent-event-bus#128). The SessionStart hook registers on the bus with
+# client_id = the Claude Code session id, which the bus adopts as its session
+# id - so the two ids are the same value. The CLI reads this env var when
+# --session-id is omitted. No-op outside Claude Code or on versions that don't
+# expose CLAUDE_CODE_SESSION_ID to subprocesses.
+if [[ -n "${CLAUDE_CODE_SESSION_ID:-}" && -z "${AGENT_EVENT_BUS_SESSION_ID:-}" ]]; then
+    export AGENT_EVENT_BUS_SESSION_ID="$CLAUDE_CODE_SESSION_ID"
+fi
+
 # Set up Homebrew PATH for macOS
 if [[ "$(uname)" == "Darwin" ]]; then
 	if [[ -f "/opt/homebrew/bin/brew" ]]; then

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -182,6 +182,12 @@ case "$1" in
         ;;
 
     events)
+        # Record argv when asked - pins the noise-policy split (session-start
+        # uses server-side --min-level; the drain lib keeps client-side --exclude)
+        if [[ -n "${MOCK_EVENTS_ARGS_FILE:-}" ]]; then
+            printf '%s ' "$@" >> "$MOCK_EVENTS_ARGS_FILE"
+            printf '\n' >> "$MOCK_EVENTS_ARGS_FILE"
+        fi
         # Parse args - real CLI also accepts --order, --include, --exclude, --timeout, --limit
         # Currently only --session-id affects output; others are accepted but ignored
         session_id=""
@@ -339,6 +345,22 @@ test_session_start_fetches_events() {
     # Should fetch and display events after registration
     # Output should contain BOTH registration confirmation AND event content
     [[ "$output" == *"Registered"* ]] && [[ "$output" == *"task_completed"* ]]
+}
+
+test_session_start_uses_min_level() {
+    setup_mock_event_bus_cli
+
+    local args_file="$TEST_TMP/session-start-events-args"
+    rm -f "$args_file"
+    echo '{"session_id":"test-client","cwd":"/tmp"}' | \
+        MOCK_EVENTS_ARGS_FILE="$args_file" \
+        bash "$HOOKS_DIR/session-start.sh" >/dev/null 2>&1 || true
+
+    # Pins the server-side noise policy: the recent-events fetch passes
+    # --min-level info, and the legacy --exclude fallback stays idle (the
+    # mock understands --min-level and returns events, so no retry fires).
+    grep -q -- '--min-level info' "$args_file" && \
+    ! grep -q -- '--exclude' "$args_file"
 }
 
 # ============================================================================
@@ -1794,6 +1816,12 @@ done
 
 case "${1:-}" in
     events)
+        # Record argv when asked - pins the noise-policy split (session-start
+        # uses server-side --min-level; the drain lib keeps client-side --exclude)
+        if [[ -n "${MOCK_EVENTS_ARGS_FILE:-}" ]]; then
+            printf '%s ' "$@" >> "$MOCK_EVENTS_ARGS_FILE"
+            printf '\n' >> "$MOCK_EVENTS_ARGS_FILE"
+        fi
         peek=0
         json=0
         limit=""
@@ -2007,6 +2035,24 @@ test_drain_directed_blocks_on_help_needed_repo() {
     [[ "$output" == *"help_needed"* ]]
 }
 
+test_eventbus_lib_uses_client_side_exclude() {
+    # The drain lib must KEEP the client-side denylist: its bounded consume
+    # relies on --exclude filtering client-side so peek and consume agree on
+    # the same raw event window (see the rationale in lib/eventbus-collect.sh).
+    # A "unification" onto server-side --min-level would silently break that.
+    setup_mock_drain_cli
+
+    local args_file="$TEST_TMP/drain-events-args"
+    rm -f "$args_file"
+    MOCK_EVENTS_ARGS_FILE="$args_file" bash -c '
+        source "'"$HOOKS_DIR"'/lib/eventbus-collect.sh"
+        eb_fetch_events "sess-1" consume text asc
+    ' >/dev/null 2>&1 || true
+
+    grep -q -- '--exclude' "$args_file" && \
+    ! grep -q -- '--min-level' "$args_file"
+}
+
 # ============================================================================
 # Run all tests
 # ============================================================================
@@ -2025,6 +2071,7 @@ main() {
     run_test "integration: happy path" "test_session_start_happy_path"
     run_test "integration: parses session_id" "test_session_start_parses_session_id"
     run_test "integration: fetches events" "test_session_start_fetches_events"
+    run_test "integration: uses server-side --min-level (noise policy)" "test_session_start_uses_min_level"
     run_test "integration: populates statusline cache" "test_session_start_populates_cache"
     run_test "integration: skips cache without display_id" "test_session_start_cache_skipped_without_display_id"
     echo ""
@@ -2170,6 +2217,7 @@ main() {
     run_test "silent on no events (no consume)" "test_drain_directed_silent_on_no_events"
     run_test "bounded consume tracks multi-event peeked count" "test_drain_directed_bounded_consume_multi_event"
     run_test "registered before enforce-insight (block precedence)" "test_drain_directed_registered_before_enforce_insight"
+    run_test "lib keeps client-side --exclude (bounded-consume safety)" "test_eventbus_lib_uses_client_side_exclude"
     echo ""
 
     # Summary

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -188,6 +188,16 @@ case "$1" in
             printf '%s ' "$@" >> "$MOCK_EVENTS_ARGS_FILE"
             printf '\n' >> "$MOCK_EVENTS_ARGS_FILE"
         fi
+        # Simulate a CLI predating --min-level (agent-event-bus#129): argparse
+        # rejects an unknown flag with a usage error on stderr and exit 2.
+        if [[ -n "${MOCK_REJECT_MIN_LEVEL:-}" ]]; then
+            for arg in "$@"; do
+                if [[ "$arg" == "--min-level" ]]; then
+                    echo "usage: agent-event-bus-cli events [...] (unrecognized arguments: --min-level)" >&2
+                    exit 2
+                fi
+            done
+        fi
         # Parse args - real CLI also accepts --order, --include, --exclude, --timeout, --limit
         # Currently only --session-id affects output; others are accepted but ignored
         session_id=""
@@ -361,6 +371,25 @@ test_session_start_uses_min_level() {
     # mock understands --min-level and returns events, so no retry fires).
     grep -q -- '--min-level info' "$args_file" && \
     ! grep -q -- '--exclude' "$args_file"
+}
+
+test_session_start_min_level_fallback() {
+    setup_mock_event_bus_cli
+
+    local args_file="$TEST_TMP/session-start-fallback-args"
+    rm -f "$args_file"
+    local output
+    output=$(echo '{"session_id":"test-client","cwd":"/tmp"}' | \
+        MOCK_EVENTS_ARGS_FILE="$args_file" MOCK_REJECT_MIN_LEVEL=1 \
+        bash "$HOOKS_DIR/session-start.sh" 2>&1) || true
+
+    # Exercises the deploy-ordering fallback end to end: an old CLI rejects
+    # --min-level with an argparse usage error (exit 2), and the hook must
+    # retry with the legacy --exclude denylist and still surface events.
+    # The argv file shows both attempts, in order.
+    [[ "$output" == *"task_completed"* ]] && \
+    sed -n '1p' "$args_file" | grep -q -- '--min-level' && \
+    sed -n '2p' "$args_file" | grep -q -- '--exclude'
 }
 
 # ============================================================================
@@ -2072,6 +2101,7 @@ main() {
     run_test "integration: parses session_id" "test_session_start_parses_session_id"
     run_test "integration: fetches events" "test_session_start_fetches_events"
     run_test "integration: uses server-side --min-level (noise policy)" "test_session_start_uses_min_level"
+    run_test "integration: falls back to --exclude on old CLI (exit 2)" "test_session_start_min_level_fallback"
     run_test "integration: populates statusline cache" "test_session_start_populates_cache"
     run_test "integration: skips cache without display_id" "test_session_start_cache_skipped_without_display_id"
     echo ""

--- a/tests/test-hooks.sh
+++ b/tests/test-hooks.sh
@@ -188,7 +188,7 @@ case "$1" in
         while [[ $# -gt 1 ]]; do
             case "$2" in
                 --session-id) session_id="$3"; shift 2 ;;
-                --order|--include|--exclude|--timeout|--limit) shift 2 ;;  # Accept but ignore
+                --order|--include|--exclude|--min-level|--timeout|--limit) shift 2 ;;  # Accept but ignore
                 *) shift ;;
             esac
         done
@@ -1803,7 +1803,7 @@ case "${1:-}" in
                 --peek) peek=1; shift ;;
                 --json) json=1; shift ;;
                 --limit) limit="$2"; shift 2 ;;
-                --session-id|--order|--exclude|--timeout|--url) shift 2 ;;
+                --session-id|--order|--exclude|--min-level|--timeout|--url) shift 2 ;;
                 --resume) shift ;;
                 *) shift ;;
             esac


### PR DESCRIPTION
Wires the hooks up to the two features that landed in evansenter/agent-event-bus#132 — without this, both deliver nothing in practice.

## Session attribution (closes the dotfiles half of agent-event-bus#128)

`.exports` maps `CLAUDE_CODE_SESSION_ID` → `AGENT_EVENT_BUS_SESSION_ID` when running inside Claude Code. Verified empirically that `CLAUDE_CODE_SESSION_ID` is present in Bash-tool subprocess environments, and the two ids are the same value by construction: `session-start.sh` registers on the bus with `client_id` = the CC session id, which the bus adopts as its session id. The bus CLI reads the env var when `--session-id` is omitted (both `publish` and `events`), so subagent and workflow-step publishes stop being `anonymous`. Defensive no-op outside Claude Code or on versions that don't expose the variable.

## Server-side signal levels (consumes agent-event-bus#129)

`session-start.sh`'s recent-events fetch switches from `--exclude session_registered,session_unregistered` to `--min-level info` — one canonical noise policy on the server, and it now also drops the `ci_watching`/`task_started`/`ci_rerun` churn the old two-type list let through.

**Deliberately not migrated:** the shared `eventbus-collect.sh` lib keeps its client-side `EB_EXCLUDE` denylist, now with a comment explaining why. The Stop-hook drain's bounded consume (peek N filtered events, consume with `--limit N`) requires peek and consume to agree on the raw event window, which client-side `--exclude` guarantees and server-side `--min-level` does not — a `--min-level` consume bounded to the filtered count would advance the cursor past a different raw window than the peek saw, risking consumed-but-never-surfaced events. Migrating that path needs a cursor-ack primitive on the bus (filed as agent-event-bus#134).

## Verification of the `.exports` mapping (round-1/2 Important)

The review correctly noted that `CLAUDE_CODE_SESSION_ID` being *present* is the precondition, not the outcome — the mapping only fires if `~/.exports` is evaluated in a shell where the variable is already set. Verified end-to-end in a live Claude Code session (Bash tool subprocess):

- `printenv CLAUDE_CODE_SESSION_ID` → present (`067fd316-…`, the live session's id)
- evaluating the `.exports` mapping in that shell exports `AGENT_EVENT_BUS_SESSION_ID` with the identical value
- the bus CLI's env-attribution path therefore attributes to `067fd316-…` — the same id the SessionStart hook registers as `client_id`, so publishes land non-anonymous under the registered session

Caveat: that session runs in a Linux container, not the macOS login-shell chain this repo actually configures, so the one machine-specific link (does *your* Bash-tool startup snapshot evaluate `.exports` after the session id is injected?) deserves a one-line spot check after merging: run `printenv AGENT_EVENT_BUS_SESSION_ID` in a Bash tool call on the Mac and compare it with the id in the SessionStart "Registered on event bus as:" line. If it comes back empty, the fallback is the bus-side one the review sketched (CLI reading `CLAUDE_CODE_SESSION_ID` directly) — a follow-up PR in agent-event-bus, not this one.

## Round-1 review fixes (0274e91)

- **Version-skew fallback** in `session-start.sh`: retry once with the legacy client-side `--exclude` denylist when the `--min-level` fetch fails on an out-of-date CLI, so such a machine degrades to extra noise instead of silently losing all startup context.
- **README**: the split noise policy (server-side `--min-level` for session-start, client-side `EB_EXCLUDE` for the drain path) is now documented in the Event-drain architecture section, with a pointer to the lib rationale and agent-event-bus#134; the session-start entry describes the new fetch and its fallback.
- **Argv-pinning tests**: both mock CLIs record `events` argv to `MOCK_EVENTS_ARGS_FILE` when set; `test_session_start_uses_min_level` asserts `--min-level info` is passed and no `--exclude` fallback fires, `test_eventbus_lib_uses_client_side_exclude` asserts `eb_fetch_events` keeps `--exclude` and never migrates to `--min-level` — pinning both sides of the policy split.

## Round-2 review fixes (89cecd2)

- **Fallback is exit-code-gated**: it now fires only when the first fetch exits 2 (argparse usage error — the flag wasn't understood), not on any empty result. A down/timed-out bus exits 1, where a retry can't help and would make every offline session start pay a second ~200ms timeout.
- **Fallback path is tested**: the mock can simulate an old CLI (`MOCK_REJECT_MIN_LEVEL=1` → usage error on stderr, exit 2, after recording argv); `test_session_start_min_level_fallback` asserts events are still surfaced and the argv file shows the failed `--min-level` attempt followed by the `--exclude` retry, in order.

## Testing

`bash -n` clean on all changed scripts; test mocks updated to accept `--min-level`, record argv, and simulate an old CLI; three new tests registered (session-start noise policy, fallback path, drain-lib denylist). `tests/test-hooks.sh` was not runnable in this Linux container (it hangs before producing output — appears to expect a macOS/interactive environment), so CI's Hooks job is the authoritative run; please also give it one local run before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFp3uCezpvbeyAMYnNrQ4R

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFp3uCezpvbeyAMYnNrQ4R)_