### PR TITLE
docs(ci): correct what a green claude-review check actually means

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,10 +25,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        # Pinned to v4 (Node20). A v5 bump here can't be CI-verified: the claude-review
-        # action requires this workflow file to match main, so its check fails on any PR
-        # that edits it (the action says to ignore that). dotfiles.yml is bumped to v5
-        # (verified green); revisit these two once v5 is confirmed safe for the action.
+        # Pinned to v4 (Node20). A v5 bump here can't be CI-verified: the action refuses
+        # to run when this workflow file differs from the copy on the default branch (a
+        # security control — a PR that can rewrite the workflow would otherwise direct
+        # the reviewer while holding its token). Note it does NOT fail: it logs
+        # "Skipping action due to workflow validation" and exits *success*, so a green
+        # claude-review on a workflow-editing PR means the review never ran, not that it
+        # passed. Don't read it as a pass. dotfiles.yml is bumped to v5 (verified green);
+        # revisit these two once v5 is confirmed safe for the action.
         uses: actions/checkout@v4
         with:
           fetch-depth: 1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,10 +26,14 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        # Pinned to v4 (Node20). A v5 bump here can't be CI-verified: the claude-review
-        # action requires this workflow file to match main, so its check fails on any PR
-        # that edits it (the action says to ignore that). dotfiles.yml is bumped to v5
-        # (verified green); revisit these two once v5 is confirmed safe for the action.
+        # Pinned to v4 (Node20). A v5 bump here can't be CI-verified: the action refuses
+        # to run when this workflow file differs from the copy on the default branch (a
+        # security control — a PR that can rewrite the workflow would otherwise direct
+        # the reviewer while holding its token). Note it does NOT fail: it logs
+        # "Skipping action due to workflow validation" and exits *success*, so a green
+        # claude-review on a workflow-editing PR means the review never ran, not that it
+        # passed. Don't read it as a pass. dotfiles.yml is bumped to v5 (verified green);
+        # revisit these two once v5 is confirmed safe for the action.
         uses: actions/checkout@v4
         with:
           fetch-depth: 1

--- a/docs/work-review-cycle.md
+++ b/docs/work-review-cycle.md
@@ -128,6 +128,8 @@ Because the review runs on every push, and the author's answer to a review *is* 
 - Dismisses stale reviews on new pushes (bot re-reviews automatically)
 - Admin bypass available if bot is down
 
+**A green `claude-review` check does not always mean a review happened.** The action refuses to run when the workflow file on the PR differs from the copy on the default branch — a security control, since a PR that can rewrite the workflow could otherwise direct the reviewer while it holds the token. It logs `Skipping action due to workflow validation` and exits **success**, so on any PR that edits `.github/workflows/claude*.yml` the check goes green in ~10s without reviewing anything. Check for an actual review verdict (`gh pr view --json reviews`) rather than trusting the check, and expect the first PR that adds these workflows to a new repo to behave the same way.
+
 ## Event Bus Integration
 
 The workflow publishes events for cross-session coordination:


### PR DESCRIPTION
Follow-up to #331. Documentation only — no behavior change.

The comment in both `claude*.yml` workflows said the claude-review check "fails on any PR that edits it." It doesn't. The action logs `Skipping action due to workflow validation` and exits **success**:

```
##[warning]Skipping action due to workflow validation: Workflow validation failed.
The workflow file must exist and have identical content to the version on the
repository's default branch.
...
Exiting due to workflow validation skip
##[end-action id=claude-review.run;outcome=success;conclusion=success]
```

That's the more dangerous shape to be wrong about. "Fails" is loud and self-correcting; "succeeds without reviewing" looks identical to a pass. #331 merged exactly that way — five green checks, one of which certified nothing.

## Changes

- Both workflow comments now say the action *skips and exits success*, explain why the validation exists (a PR that can rewrite the workflow could otherwise direct the reviewer while it holds the token), and state plainly not to read the green check as a pass.
- `docs/work-review-cycle.md` gains the same caveat in its branch-protection section, pointing at `gh pr view --json reviews` as the thing that actually tells you a verdict was posted.

The validation itself is correct and I'm not proposing to change it — this is only about what the green check is understood to mean. Upstream could distinguish the two with a `neutral` conclusion, but that's `claude-code-action`'s call.

Note this PR edits the workflow files, so `claude-review` will skip on it too, for the reason it now documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yN39aeZZVCJCRBFLBgXp5

---
_Generated by [Claude Code](https://claude.ai/code/session_016yN39aeZZVCJCRBFLBgXp5)_