### PR TITLE
ci: actually run the bootstrap tests in the Bootstrap job

### DIFF
--- a/.github/workflows/dotfiles.yml
+++ b/.github/workflows/dotfiles.yml
@@ -52,6 +52,7 @@ jobs:
           test -x bootstrap.sh
           test -x uninstall.sh
           test -x tests/test-hooks.sh
+          test -x tests/test-bootstrap.sh
 
       - name: Check for required files
         run: |
@@ -59,3 +60,11 @@ jobs:
           test -f home/.gitconfig
           test -f home/.vimrc
           test -f home/.tmux.conf
+
+      # The checks above only assert files exist and are executable — they pass
+      # through any logic regression in bootstrap.sh. This is the step that
+      # actually tests it (flag parsing, host-gating, LaunchAgent install,
+      # self-update re-exec). It stubs launchctl/brew/curl, so no macOS-only
+      # binaries are needed.
+      - name: Run bootstrap tests
+        run: make test-bootstrap


### PR DESCRIPTION
`make check` runs four gates: `lint`, `test`, `test-hooks`, `test-bootstrap`. CI has four jobs whose names match. Three line up. One doesn't:

| CI job | What it ran | Required? |
|---|---|---|
| Lint | `make lint` | ✅ |
| Test | `make test` | ✅ |
| Hooks | `make test-hooks` (2,263 lines) | ❌ |
| Bootstrap | **not** `make test-bootstrap` — 3 `test -x` + 4 `test -f` | ✅ |

`grep -rn test-bootstrap .github/` returned nothing. Those 689 lines only ever ran when someone typed `make check` locally — no PR in this repo has been gated on them.

And the job's name hides it: a required check called `Bootstrap` reads as "the bootstrap tests ran." It asserted `bootstrap.sh` is executable and four dotfiles exist — seven assertions that pass through essentially any logic regression in the 1,200-line script they're named after, including ones `test-bootstrap.sh` was written to catch (flag parsing, host-gating, LaunchAgent install, self-update re-exec).

## Changes

- New `Run bootstrap tests` step: `make test-bootstrap`, with a comment explaining why the existing checks don't cover it.
- `test -x tests/test-bootstrap.sh` added alongside the existing `test-hooks.sh` check.

## Verified before wiring it up

Since the suite had never run in CI, I checked it hadn't rotted rather than assuming:

- **Passes 44/44** on Linux in this container.
- **No macOS-only dependencies.** Its `launchctl` references write to a stubbed `launchctl.calls` file; `brew` and `curl` appear only inside grep patterns and comments. Nothing beyond `bash` and `sed` is needed on `ubuntu-latest`.
- YAML parses; the `bootstrap` job's steps are as intended.

## Worth flagging

**This makes a required check meaningfully stricter.** `Bootstrap` gates merges and could previously only fail on a missing or non-executable file; it can now fail on behavior. That's the point, but it's a real change in what can block a merge — if `test-bootstrap.sh` turns out to be flaky on `ubuntu-latest` in a way it isn't locally, it will block PRs rather than just being noisy.

**Not addressed here:** `Hooks` still isn't a required check, so the 2,263-line hook suite remains advisory and can go red without blocking anything. That's a repo-settings change I can't make from this session, and worth checking whether it was left out deliberately (e.g. past flakiness) before making it blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yN39aeZZVCJCRBFLBgXp5

---
_Generated by [Claude Code](https://claude.ai/code/session_016yN39aeZZVCJCRBFLBgXp5)_